### PR TITLE
[4.3.x] Remove the netcat from the deployment startup probes

### DIFF
--- a/all-in-one/templates/am/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/wso2am-deployment.yaml
@@ -86,8 +86,9 @@ spec:
             failureThreshold: {{ .Values.wso2.deployment.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /services/Version
-              port: 9763
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.wso2.deployment.readinessProbe.failureThreshold }}

--- a/all-in-one/templates/am/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/wso2am-deployment.yaml
@@ -73,7 +73,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - nc -z localhost 9443
+                - timeout 1 bash -c "</dev/tcp/localhost/9443"
             initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}         

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost {{ add 9443 .Values.wso2.apim.portOffset }}
+              - timeout 1 bash -c "</dev/tcp/localhost/{{ add 9443 .Values.wso2.apim.portOffset }}"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -80,7 +80,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost {{ add 9443 .Values.wso2.apim.portOffset }}
+              - timeout 1 bash -c "</dev/tcp/localhost/{{ add 9443 .Values.wso2.apim.portOffset }}"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -80,7 +80,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost {{ add 9443 .Values.wso2.apim.portOffset }}
+              - timeout 1 bash -c "</dev/tcp/localhost/{{ add 9443 .Values.wso2.apim.portOffset }}"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -93,8 +93,9 @@ spec:
           failureThreshold: {{ .Values.wso2.deployment.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-              path: /services/Version
-              port: {{ add 9763 .Values.wso2.apim.portOffset }}
+            path: /api/am/gateway/v2/server-startup-healthcheck
+            port: {{ add 9443 .Values.wso2.apim.portOffset }}
+            scheme: HTTPS
           initialDelaySeconds: {{ .Values.wso2.deployment.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.readinessProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.readinessProbe.failureThreshold }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -82,7 +82,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost 9443
+              - timeout 1 bash -c "</dev/tcp/localhost/9443"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -83,7 +83,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost 9443
+              - timeout 1 bash -c "</dev/tcp/localhost/9443"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}


### PR DESCRIPTION
## Purpose
This PR adds the following changes,
- [Remove netcat from the deployment startup probes](https://github.com/wso2/helm-apim/commit/b32f288950318dd974e762e974dd9255b536e67e)
- [Update gateway readiness probe to healthcheck endpoint](https://github.com/wso2/helm-apim/commit/b552a6d7147ad2a1d59be1bd051d52a910c2b0be)