### PR TITLE
Remove netcat from the deployment startup probes

### DIFF
--- a/all-in-one/templates/am/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/wso2am-deployment.yaml
@@ -73,7 +73,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - nc -z localhost 9443
+                - timeout 1 bash -c "</dev/tcp/localhost/9443"
             initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}         

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost {{ add 9443 .Values.wso2.apim.portOffset }}
+              - timeout 1 bash -c "</dev/tcp/localhost/{{ add 9443 .Values.wso2.apim.portOffset }}"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -80,7 +80,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost {{ add 9443 .Values.wso2.apim.portOffset }}
+              - timeout 1 bash -c "</dev/tcp/localhost/{{ add 9443 .Values.wso2.apim.portOffset }}"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -80,7 +80,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost {{ add 9443 .Values.wso2.apim.portOffset }}
+              - timeout 1 bash -c "</dev/tcp/localhost/{{ add 9443 .Values.wso2.apim.portOffset }}"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -82,7 +82,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost 9443
+              - timeout 1 bash -c "</dev/tcp/localhost/9443"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -83,7 +83,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost 9443
+              - timeout 1 bash -c "</dev/tcp/localhost/9443"
           initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}


### PR DESCRIPTION
## Purpose
This PR removes the netcat library from the deployment startup probes.