### PR TITLE
Add missing configs

### DIFF
--- a/all-in-one/confs/deployment.toml
+++ b/all-in-one/confs/deployment.toml
@@ -476,3 +476,8 @@ shared_db_password = {{ .Values.wso2.apim.configurations.databases.shared_db.pas
 supported_languages = {{ toJson .Values.wso2.apim.configurations.sdk.supportedLanguages }}
 {{- end }}
 {{- end }}
+
+[apim.organization_based_access_control]
+enable = {{ .Values.wso2.apim.configurations.organization_based_access_control.enabled }}
+organization_name_local_claim = {{ .Values.wso2.apim.configurations.organization_based_access_control.organization_name_local_claim | quote }}
+organization_id_local_claim = {{ .Values.wso2.apim.configurations.organization_based_access_control.organization_id_local_claim | quote }}

--- a/all-in-one/confs/deployment.toml
+++ b/all-in-one/confs/deployment.toml
@@ -114,6 +114,9 @@ name = {{ $env.name | quote }}
 type = {{ $env.type | quote }}
 gateway_type = {{ $env.gatewayType | quote }}
 provider = {{ $env.provider | quote }}
+{{- if $env.visibility }}
+visibility = {{ toJson $env.visibility }}
+{{- end}}
 display_in_api_console = {{ $env.displayInApiConsole }}
 description = {{ $env.description | quote }}
 show_as_token_endpoint_url = {{ $env.showAsTokenEndpointUrl }}

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -323,6 +323,7 @@ wso2:
           type: "hybrid"
           gatewayType: "Regular"
           provider: "wso2"
+          visibility:
           displayInApiConsole: true
           description: "This is a hybrid gateway that handles both production and sandbox token traffic."
           showAsTokenEndpointUrl: true

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -566,6 +566,12 @@ wso2:
       sdk:
         supportedLanguages: ["android", "java", "csharp", "dart", "groovy", "javascript", "jmeter", "perl", "php", "python", "ruby", "swift5", "clojure"]
 
+      # Organization level access control configurations
+      organization_based_access_control:
+        enabled: true
+        organization_name_local_claim: "http://wso2.org/claims/organization"
+        organization_id_local_claim: "http://wso2.org/claims/organizationId" 
+
   deployment:
     # Container image configurations
     image:

--- a/distributed/control-plane/confs/instance-1/deployment.toml
+++ b/distributed/control-plane/confs/instance-1/deployment.toml
@@ -349,3 +349,8 @@ server_url = "{{ .Values.wso2.apim.configurations.transactionCounter.serverUrl }
 {{- else }}
 enable = false
 {{- end }}
+
+[apim.organization_based_access_control]
+enable = {{ .Values.wso2.apim.configurations.organization_based_access_control.enabled }}
+organization_name_local_claim = {{ .Values.wso2.apim.configurations.organization_based_access_control.organization_name_local_claim | quote }}
+organization_id_local_claim = {{ .Values.wso2.apim.configurations.organization_based_access_control.organization_id_local_claim | quote }}

--- a/distributed/control-plane/confs/instance-1/deployment.toml
+++ b/distributed/control-plane/confs/instance-1/deployment.toml
@@ -113,6 +113,9 @@ name = {{ $env.name | quote }}
 type = {{ $env.type | quote }}
 gateway_type = {{ $env.gatewayType | quote }}
 provider = {{ $env.provider | quote }}
+{{- if $env.visibility }}
+visibility = {{ toJson $env.visibility }}
+{{- end}}
 display_in_api_console = {{ $env.displayInApiConsole }}
 description = {{ $env.description | quote }}
 show_as_token_endpoint_url = {{ $env.showAsTokenEndpointUrl }}

--- a/distributed/control-plane/confs/instance-2/deployment.toml
+++ b/distributed/control-plane/confs/instance-2/deployment.toml
@@ -335,3 +335,8 @@ server_url = "{{ .Values.wso2.apim.configurations.transactionCounter.serverUrl }
 {{- else }}
 enable = false
 {{- end }}
+
+[apim.organization_based_access_control]
+enable = {{ .Values.wso2.apim.configurations.organization_based_access_control.enabled }}
+organization_name_local_claim = {{ .Values.wso2.apim.configurations.organization_based_access_control.organization_name_local_claim | quote }}
+organization_id_local_claim = {{ .Values.wso2.apim.configurations.organization_based_access_control.organization_id_local_claim | quote }}

--- a/distributed/control-plane/confs/instance-2/deployment.toml
+++ b/distributed/control-plane/confs/instance-2/deployment.toml
@@ -104,6 +104,9 @@ name = {{ $env.name | quote }}
 type = {{ $env.type | quote }}
 gateway_type = {{ $env.gatewayType | quote }}
 provider = {{ $env.provider | quote }}
+{{- if $env.visibility }}
+visibility = {{ toJson $env.visibility }}
+{{- end}}
 display_in_api_console = {{ $env.displayInApiConsole }}
 description = {{ $env.description | quote }}
 show_as_token_endpoint_url = {{ $env.showAsTokenEndpointUrl }}

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -405,6 +405,12 @@ wso2:
         enabled: false
         serviceUrl: ""
 
+      # Organization level access control configurations
+      organization_based_access_control:
+        enabled: true
+        organization_name_local_claim: "http://wso2.org/claims/organization"
+        organization_id_local_claim: "http://wso2.org/claims/organizationId" 
+
   deployment:
     # Container image configurations
     image:

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -302,6 +302,7 @@ wso2:
           type: "hybrid"
           gatewayType: "Regular"
           provider: "wso2"
+          visibility:
           displayInApiConsole: true
           description: "This is a hybrid gateway that handles both production and sandbox token traffic."
           showAsTokenEndpointUrl: true


### PR DESCRIPTION
## Purpose
This pull request introduces changes to the configuration files to add support for visibility settings and organization-based access control. The updates address the need to control visibility settings and implement organization-based access management in the deployment configurations.

## Goals
This feature/fix will introduce the following changes:
Conditional visibility settings to the deployment configurations.
Addition of visibility field to the wso2 configuration.
Implementation of organization-based access control settings in the deployment configurations.
Enable organization-based access control configurations in the wso2 configuration.

## Approach
[all-in-one/confs/deployment.toml](https://github.com/wso2/helm-apim/compare/main...kavindasr:helm-apim:add-missing-configs?expand=1): Added conditional visibility settings to the deployment configuration.
[distributed/control-plane/confs/instance-1/deployment.toml](https://github.com/wso2/helm-apim/compare/main...kavindasr:helm-apim:add-missing-configs?expand=1): Added conditional visibility settings to the deployment configuration.
[distributed/control-plane/confs/instance-2/deployment.toml](https://github.com/wso2/helm-apim/compare/main...kavindasr:helm-apim:add-missing-configs?expand=1): Added conditional visibility settings to the deployment configuration.
[all-in-one/values.yaml](https://github.com/wso2/helm-apim/compare/main...kavindasr:helm-apim:add-missing-configs?expand=1): Added visibility field to the wso2 configuration.
[distributed/control-plane/values.yaml](https://github.com/wso2/helm-apim/compare/main...kavindasr:helm-apim:add-missing-configs?expand=1): Added visibility field to the wso2 configuration.