### PR TITLE
Add frontend settings

### DIFF
--- a/all-in-one/confs/frontend-confs/admin-settings.json
+++ b/all-in-one/confs/frontend-confs/admin-settings.json
@@ -1,0 +1,25 @@
+{
+  "app": {
+    "context": "/admin",
+    "customUrl": {
+      "enabled": false,
+      "forwardedHeader": "X-Forwarded-For"
+    },
+    "origin": {
+      "host": "localhost"
+    },
+    "workflows": {
+      "limit": 30
+    },
+    "feedback": {
+      "enable": false,
+      "serviceURL": ""
+    },
+    "singleLogout": {
+      "enabled": true,
+      "timeout": 2000
+    },
+    "logoutSessionStateAppender" : "OIDC" ,
+    "docUrl": "https://apim.docs.wso2.com/en/4.5.0/"
+  }
+}

--- a/all-in-one/confs/frontend-confs/devportal-settings.json
+++ b/all-in-one/confs/frontend-confs/devportal-settings.json
@@ -1,0 +1,63 @@
+{
+    "app": {
+        "context": "/devportal",
+        "customUrl": {
+            "enabled": false,
+            "forwardedHeader": "X-Forwarded-For"
+        },
+        "origin": {
+            "host": "localhost"
+        },
+        "subscriptionLimit": 1000,
+        "subscribeApplicationLimit": 5000,
+        "isPassive": true,
+        "singleLogout": {
+            "enabled": true,
+            "timeout": 4000
+        },
+        "logoutSessionStateAppender" : "OIDC" ,
+        "propertyDisplaySuffix": "__display",
+        "markdown": {
+            "skipHtml": true,
+            "syntaxHighlighterProps": {
+                "showLineNumbers": false
+            },
+            "syntaxHighlighterDarkTheme": false
+        },
+        "sanitizeHtml": {
+            "allowedTags": false,
+            "allowedAttributes": false
+        },
+        "reactHTMLParser": {
+            "decodeEntries": true,
+            "tagsNotAllowed": []
+        }
+    },
+    "grantTypes": {
+        "authorization_code": "Code",
+        "implicit": "Implicit",
+        "refresh_token": "Refresh Token",
+        "password": "Password",
+        "iwa:ntlm": "IWA-NTLM",
+        "client_credentials": "Client Credentials",
+        "urn:ietf:params:oauth:grant-type:saml2-bearer": "SAML2",
+        "urn:ietf:params:oauth:grant-type:jwt-bearer": "JWT",
+        "kerberos": "Kerberos",
+        "urn:ietf:params:oauth:grant-type:device_code": "Device Code"
+    },
+    "passwordChange": {
+        "guidelinesEnabled": false,
+        "policyList": [
+            "Policy 1",
+            "Policy 2",
+            "Policy 3"
+        ]
+    },
+    "apis": {
+        "tileDisplayInfo": {
+            "showMonetizedState": false,
+            "showBusinessDetails": false,
+            "showTechnicalDetails": false
+        }
+    }
+}

--- a/all-in-one/confs/frontend-confs/publisher-settings.json
+++ b/all-in-one/confs/frontend-confs/publisher-settings.json
@@ -1,0 +1,102 @@
+{
+    "app": {
+        "context": "/publisher",
+        "customUrl": {
+            "enabled": false,
+            "forwardedHeader": "X-Forwarded-For"
+        },
+        "origin": {
+            "host": "localhost"
+        },
+        "feedback": {
+            "enable": false,
+            "serviceURL": ""
+        },
+        "singleLogout": {
+            "enabled": true,
+            "timeout": 4000
+        },
+        "logoutSessionStateAppender" : "OIDC" ,
+        "throttlingPolicyLimit": 80,
+        "operationPolicyCount": 500,
+        "documentCount": 1000,
+        "propertyDisplaySuffix": "__display",
+        "markdown": {
+            "skipHtml": true,
+            "syntaxHighlighterProps": {
+                "showLineNumbers": false
+            },
+            "syntaxHighlighterDarkTheme": false,
+            "template": {
+                "howTo": "",
+                "sample": "",
+                "other": ""
+            }
+        },
+        "reactHTMLParser": {
+          "decodeEntries": true,
+          "tagsNotAllowed": []
+        },
+        "workflows": {
+          "limit": 30
+        },
+        "loadDefaultLocales": false,
+        "supportedDocTypes": "application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword, application/pdf, text/plain, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.oasis.opendocument.text, application/vnd.oasis.opendocument.spreadsheet, application/json, application/x-yaml, .yaml, .md",
+        "docUrl": "https://apim.docs.wso2.com/en/4.5.0/"
+    },
+    "serviceCatalogDefinitionTypes": {
+      "OAS2": "Swagger",
+      "OAS3": "Open API V3",
+      "WSDL1": "WSDL 1",
+      "WSDL2": "WSDL 2",
+      "GRAPHQL_SDL": "GraphQL SDL",
+      "ASYNC_API": "AsyncAPI"
+    },
+    "serviceCatalogSecurityTypes": {
+      "BASIC": "Basic",
+      "DIGEST": "Digest",
+      "OAUTH2": "OAuth2",
+      "NONE": "None",
+      "X509": "X509",
+      "API_KEY": "API Key"
+    },
+  "apis": {
+    "alwaysShowDeploySampleButton": true,
+    "showMultiVersionPolicies": false,
+    "tileDisplayInfo": {
+      "showMonetizedState": false,
+      "showBusinessDetails": false,
+      "showTechnicalDetails": false
+    },
+    "endpoint": {
+      "aws": {
+        "regions": {
+          "us-east-1": "us-east-1: US East (N. Virginia)",
+          "us-east-2": "us-east-2: US East (Ohio)",
+          "us-west-1": "us-west-1: US West (N. California)",
+          "us-west-2": "us-west-2: US West (Oregon)",
+          "af-south-1": "af-south-1: Africa (Cape Town)",
+          "ap-east-1": "ap-east-1: Asia Pacific (Hong Kong)",
+          "ap-south-1": "ap-south-1: Asia Pacific (Mumbai)",
+          "ap-northeast-1": "ap-northeast-1: Asia Pacific (Tokyo)",
+          "ap-northeast-2": "ap-northeast-2: Asia Pacific (Seoul)",
+          "ap-northeast-3": "ap-northeast-3: Asia Pacific (Osaka-Local)",
+          "ap-southeast-1": "ap-southeast-1: Asia Pacific (Singapore)",
+          "ap-southeast-2": "ap-southeast-2: Asia Pacific (Sydney)",
+          "ca-central-1": "ca-central-1: Canada (Central)",
+          "eu-central-1": "eu-central-1: Europe (Frankfurt)",
+          "eu-west-1": "eu-west-1: Europe (Ireland)",
+          "eu-west-2": "eu-west-2: Europe (London)",
+          "eu-south-1": "eu-south-1: Europe (Milan)",
+          "eu-west-3": "eu-west-3: Europe (Paris)",
+          "eu-north-1": "eu-north-1: Europe (Stockholm)",
+          "me-south-1": "me-south-1: Middle East (Bahrain)",
+          "sa-east-1": "sa-east-1: South America (São Paulo)"
+        }
+      }
+    },
+    "maxSubscriptionLimit": 2000,
+    "maxScopeCount": 2000
+  }
+}
+

--- a/all-in-one/templates/am/wso2am-cp-conf-settings.yaml
+++ b/all-in-one/templates/am/wso2am-cp-conf-settings.yaml
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if .Values.wso2.apim.mountFrontendConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-conf-admin-settings
+  namespace : {{ .Release.Namespace }}
+data:
+  settings.json: {{ tpl (.Files.Get "confs/frontend-confs/admin-settings.json") . | quote }}
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-conf-devportal-settings
+  namespace : {{ .Release.Namespace }}
+data:
+  settings.json: {{ tpl (.Files.Get "confs/frontend-confs/devportal-settings.json") . | quote }}
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-conf-publisher-settings
+  namespace : {{ .Release.Namespace }}
+data:
+  settings.json: {{ tpl (.Files.Get "confs/frontend-confs/publisher-settings.json") . | quote }}
+---
+{{- end }}

--- a/all-in-one/templates/am/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/wso2am-deployment.yaml
@@ -148,6 +148,17 @@ spec:
               mountPath: /home/wso2carbon/wso2-config-volume/bin/api-manager.sh
               subPath: api-manager.sh
             {{- end }}
+            {{- if .Values.wso2.apim.mountFrontendConfig }}
+            - name: wso2am-conf-admin-settings
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/admin/site/public/conf/settings.json
+              subPath: settings.json
+            - name: wso2am-conf-devportal-settings
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/devportal/site/public/theme/settings.json
+              subPath: settings.json
+            - name: wso2am-conf-publisher-settings
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/publisher/site/public/conf/settings.json
+              subPath: settings.json
+            {{- end }}
             {{- if .Values.wso2.apim.secureVaultEnabled }}
             - name: wso2am-secret-conf
               mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/security/secret-conf.properties
@@ -203,6 +214,20 @@ spec:
         - name: wso2am-sh-conf
           configMap:
             name: {{ template "am-all-in-one.fullname" . }}-conf-sh
+            defaultMode: 0407
+        {{- end }}
+        {{- if .Values.wso2.apim.mountFrontendConfig }}
+        - name: wso2am-conf-admin-settings
+          configMap:
+            name: {{ template "am-all-in-one.fullname" . }}-conf-admin-settings
+            defaultMode: 0407
+        - name: wso2am-conf-devportal-settings
+          configMap:
+            name: {{ template "am-all-in-one.fullname" . }}-conf-devportal-settings
+            defaultMode: 0407
+        - name: wso2am-conf-publisher-settings
+          configMap:
+            name: {{ template "am-all-in-one.fullname" . }}-conf-publisher-settings
             defaultMode: 0407
         {{- end }}
         {{- if .Values.wso2.apim.secureVaultEnabled }}

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -211,6 +211,8 @@ wso2:
     portOffset: 0
     # -- Startup script mount status
     mountStartupScript: false
+    # -- Frontend settings.json mount status
+    mountFrontendConfig: false
     # TOML configurations
     configurations:
       gatewayType: "Regular,APK,AWS"

--- a/distributed/control-plane/confs/frontend-confs/admin-settings.json
+++ b/distributed/control-plane/confs/frontend-confs/admin-settings.json
@@ -1,0 +1,25 @@
+{
+  "app": {
+    "context": "/admin",
+    "customUrl": {
+      "enabled": false,
+      "forwardedHeader": "X-Forwarded-For"
+    },
+    "origin": {
+      "host": "localhost"
+    },
+    "workflows": {
+      "limit": 30
+    },
+    "feedback": {
+      "enable": false,
+      "serviceURL": ""
+    },
+    "singleLogout": {
+      "enabled": true,
+      "timeout": 2000
+    },
+    "logoutSessionStateAppender" : "OIDC" ,
+    "docUrl": "https://apim.docs.wso2.com/en/4.5.0/"
+  }
+}

--- a/distributed/control-plane/confs/frontend-confs/devportal-settings.json
+++ b/distributed/control-plane/confs/frontend-confs/devportal-settings.json
@@ -1,0 +1,63 @@
+{
+    "app": {
+        "context": "/devportal",
+        "customUrl": {
+            "enabled": false,
+            "forwardedHeader": "X-Forwarded-For"
+        },
+        "origin": {
+            "host": "localhost"
+        },
+        "subscriptionLimit": 1000,
+        "subscribeApplicationLimit": 5000,
+        "isPassive": true,
+        "singleLogout": {
+            "enabled": true,
+            "timeout": 4000
+        },
+        "logoutSessionStateAppender" : "OIDC" ,
+        "propertyDisplaySuffix": "__display",
+        "markdown": {
+            "skipHtml": true,
+            "syntaxHighlighterProps": {
+                "showLineNumbers": false
+            },
+            "syntaxHighlighterDarkTheme": false
+        },
+        "sanitizeHtml": {
+            "allowedTags": false,
+            "allowedAttributes": false
+        },
+        "reactHTMLParser": {
+            "decodeEntries": true,
+            "tagsNotAllowed": []
+        }
+    },
+    "grantTypes": {
+        "authorization_code": "Code",
+        "implicit": "Implicit",
+        "refresh_token": "Refresh Token",
+        "password": "Password",
+        "iwa:ntlm": "IWA-NTLM",
+        "client_credentials": "Client Credentials",
+        "urn:ietf:params:oauth:grant-type:saml2-bearer": "SAML2",
+        "urn:ietf:params:oauth:grant-type:jwt-bearer": "JWT",
+        "kerberos": "Kerberos",
+        "urn:ietf:params:oauth:grant-type:device_code": "Device Code"
+    },
+    "passwordChange": {
+        "guidelinesEnabled": false,
+        "policyList": [
+            "Policy 1",
+            "Policy 2",
+            "Policy 3"
+        ]
+    },
+    "apis": {
+        "tileDisplayInfo": {
+            "showMonetizedState": false,
+            "showBusinessDetails": false,
+            "showTechnicalDetails": false
+        }
+    }
+}

--- a/distributed/control-plane/confs/frontend-confs/publisher-settings.json
+++ b/distributed/control-plane/confs/frontend-confs/publisher-settings.json
@@ -1,0 +1,102 @@
+{
+    "app": {
+        "context": "/publisher",
+        "customUrl": {
+            "enabled": false,
+            "forwardedHeader": "X-Forwarded-For"
+        },
+        "origin": {
+            "host": "localhost"
+        },
+        "feedback": {
+            "enable": false,
+            "serviceURL": ""
+        },
+        "singleLogout": {
+            "enabled": true,
+            "timeout": 4000
+        },
+        "logoutSessionStateAppender" : "OIDC" ,
+        "throttlingPolicyLimit": 80,
+        "operationPolicyCount": 500,
+        "documentCount": 1000,
+        "propertyDisplaySuffix": "__display",
+        "markdown": {
+            "skipHtml": true,
+            "syntaxHighlighterProps": {
+                "showLineNumbers": false
+            },
+            "syntaxHighlighterDarkTheme": false,
+            "template": {
+                "howTo": "",
+                "sample": "",
+                "other": ""
+            }
+        },
+        "reactHTMLParser": {
+          "decodeEntries": true,
+          "tagsNotAllowed": []
+        },
+        "workflows": {
+          "limit": 30
+        },
+        "loadDefaultLocales": false,
+        "supportedDocTypes": "application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword, application/pdf, text/plain, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.oasis.opendocument.text, application/vnd.oasis.opendocument.spreadsheet, application/json, application/x-yaml, .yaml, .md",
+        "docUrl": "https://apim.docs.wso2.com/en/4.5.0/"
+    },
+    "serviceCatalogDefinitionTypes": {
+      "OAS2": "Swagger",
+      "OAS3": "Open API V3",
+      "WSDL1": "WSDL 1",
+      "WSDL2": "WSDL 2",
+      "GRAPHQL_SDL": "GraphQL SDL",
+      "ASYNC_API": "AsyncAPI"
+    },
+    "serviceCatalogSecurityTypes": {
+      "BASIC": "Basic",
+      "DIGEST": "Digest",
+      "OAUTH2": "OAuth2",
+      "NONE": "None",
+      "X509": "X509",
+      "API_KEY": "API Key"
+    },
+  "apis": {
+    "alwaysShowDeploySampleButton": true,
+    "showMultiVersionPolicies": false,
+    "tileDisplayInfo": {
+      "showMonetizedState": false,
+      "showBusinessDetails": false,
+      "showTechnicalDetails": false
+    },
+    "endpoint": {
+      "aws": {
+        "regions": {
+          "us-east-1": "us-east-1: US East (N. Virginia)",
+          "us-east-2": "us-east-2: US East (Ohio)",
+          "us-west-1": "us-west-1: US West (N. California)",
+          "us-west-2": "us-west-2: US West (Oregon)",
+          "af-south-1": "af-south-1: Africa (Cape Town)",
+          "ap-east-1": "ap-east-1: Asia Pacific (Hong Kong)",
+          "ap-south-1": "ap-south-1: Asia Pacific (Mumbai)",
+          "ap-northeast-1": "ap-northeast-1: Asia Pacific (Tokyo)",
+          "ap-northeast-2": "ap-northeast-2: Asia Pacific (Seoul)",
+          "ap-northeast-3": "ap-northeast-3: Asia Pacific (Osaka-Local)",
+          "ap-southeast-1": "ap-southeast-1: Asia Pacific (Singapore)",
+          "ap-southeast-2": "ap-southeast-2: Asia Pacific (Sydney)",
+          "ca-central-1": "ca-central-1: Canada (Central)",
+          "eu-central-1": "eu-central-1: Europe (Frankfurt)",
+          "eu-west-1": "eu-west-1: Europe (Ireland)",
+          "eu-west-2": "eu-west-2: Europe (London)",
+          "eu-south-1": "eu-south-1: Europe (Milan)",
+          "eu-west-3": "eu-west-3: Europe (Paris)",
+          "eu-north-1": "eu-north-1: Europe (Stockholm)",
+          "me-south-1": "me-south-1: Middle East (Bahrain)",
+          "sa-east-1": "sa-east-1: South America (São Paulo)"
+        }
+      }
+    },
+    "maxSubscriptionLimit": 2000,
+    "maxScopeCount": 2000
+  }
+}
+

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -148,6 +148,17 @@ spec:
           mountPath: /home/wso2carbon/wso2-config-volume/bin/api-cp.sh
           subPath: api-cp.sh
         {{- end }}
+        {{- if .Values.wso2.apim.mountFrontendConfig }}
+        - name: wso2am-conf-admin-settings
+          mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/admin/site/public/conf/settings.json
+          subPath: settings.json
+        - name: wso2am-conf-devportal-settings
+          mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/devportal/site/public/theme/settings.json
+          subPath: settings.json
+        - name: wso2am-conf-publisher-settings
+          mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/publisher/site/public/conf/settings.json
+          subPath: settings.json
+        {{- end }}
         {{- if .Values.wso2.apim.secureVaultEnabled }}
         - name: wso2am-control-plane-secret-conf
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/security/secret-conf.properties
@@ -203,6 +214,20 @@ spec:
       - name: wso2am-sh-conf
         configMap:
           name: {{ template "apim-helm-cp.fullname" . }}-conf-sh
+          defaultMode: 0407
+      {{- end }}
+      {{- if .Values.wso2.apim.mountFrontendConfig }}
+      - name: wso2am-conf-admin-settings
+        configMap:
+          name: {{ template "apim-helm-cp.fullname" . }}-conf-admin-settings
+          defaultMode: 0407
+      - name: wso2am-conf-devportal-settings
+        configMap:
+          name: {{ template "apim-helm-cp.fullname" . }}-conf-devportal-settings
+          defaultMode: 0407
+      - name: wso2am-conf-publisher-settings
+        configMap:
+          name: {{ template "apim-helm-cp.fullname" . }}-conf-publisher-settings
           defaultMode: 0407
       {{- end }}
       {{- if .Values.wso2.apim.secureVaultEnabled }}

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -149,6 +149,17 @@ spec:
           mountPath: /home/wso2carbon/wso2-config-volume/bin/api-cp.sh
           subPath: api-cp.sh
         {{- end }}
+        {{- if .Values.wso2.apim.mountFrontendConfig }}
+        - name: wso2am-conf-admin-settings
+          mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/admin/site/public/conf/settings.json
+          subPath: settings.json
+        - name: wso2am-conf-devportal-settings
+          mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/devportal/site/public/theme/settings.json
+          subPath: settings.json
+        - name: wso2am-conf-publisher-settings
+          mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/webapps/publisher/site/public/conf/settings.json
+          subPath: settings.json
+        {{- end }}
         {{- if .Values.wso2.apim.secureVaultEnabled }}
         - name: wso2am-control-plane-secret-conf
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/security/secret-conf.properties
@@ -204,6 +215,20 @@ spec:
       - name: wso2am-sh-conf
         configMap:
           name: {{ template "apim-helm-cp.fullname" . }}-conf-sh
+          defaultMode: 0407
+      {{- end }}
+      {{- if .Values.wso2.apim.mountFrontendConfig }}
+      - name: wso2am-conf-admin-settings
+        configMap:
+          name: {{ template "apim-helm-cp.fullname" . }}-conf-admin-settings
+          defaultMode: 0407
+      - name: wso2am-conf-devportal-settings
+        configMap:
+          name: {{ template "apim-helm-cp.fullname" . }}-conf-devportal-settings
+          defaultMode: 0407
+      - name: wso2am-conf-publisher-settings
+        configMap:
+          name: {{ template "apim-helm-cp.fullname" . }}-conf-publisher-settings
           defaultMode: 0407
       {{- end }}
       {{- if .Values.wso2.apim.secureVaultEnabled }}

--- a/distributed/control-plane/templates/control-plane/wso2am-cp-conf-settings.yaml
+++ b/distributed/control-plane/templates/control-plane/wso2am-cp-conf-settings.yaml
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if .Values.wso2.apim.mountFrontendConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "apim-helm-cp.fullname" . }}-conf-admin-settings
+  namespace : {{ .Release.Namespace }}
+data:
+  settings.json: {{ tpl (.Files.Get "confs/frontend-confs/admin-settings.json") . | quote }}
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "apim-helm-cp.fullname" . }}-conf-devportal-settings
+  namespace : {{ .Release.Namespace }}
+data:
+  settings.json: {{ tpl (.Files.Get "confs/frontend-confs/devportal-settings.json") . | quote }}
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "apim-helm-cp.fullname" . }}-conf-publisher-settings
+  namespace : {{ .Release.Namespace }}
+data:
+  settings.json: {{ tpl (.Files.Get "confs/frontend-confs/publisher-settings.json") . | quote }}
+---
+{{- end }}

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -190,7 +190,7 @@ wso2:
     # -- Startup script mount status
     mountStartupScript: false
     # -- Frontend settings.json mount status
-    mountFrontendConfig: true
+    mountFrontendConfig: false
     # TOML configurations
     configurations:
       gatewayType: "Regular,APK,AWS"

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -189,6 +189,8 @@ wso2:
     portOffset: 0
     # -- Startup script mount status
     mountStartupScript: false
+    # -- Frontend settings.json mount status
+    mountFrontendConfig: true
     # TOML configurations
     configurations:
       gatewayType: "Regular,APK,AWS"


### PR DESCRIPTION
## Purpose
This request originates from @chamilaadhi and aims to provide users with the ability to override the default frontend settings.json files.

## Goals
- Enable mounting of settings.json files as volumes.
- Allow users to customize frontend configurations by leveraging the mountFrontendConfig option.

## Approach
- Extract settings.json files from version 4.5.0-rc2 and use them as base templates.
- Update the deployment templates to mount the settings.json files if mountFrontendConfig is enabled.