### PR TITLE
Bump Helm chart versions from 4.5.0-rc3 to 4.5.0-1

### DIFF
--- a/all-in-one/Chart.yaml
+++ b/all-in-one/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.5.0"
 description: A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 name: wso2am-all-in-one
-version: 4.5.0-rc3
+version: 4.5.0-1
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/distributed/control-plane/Chart.yaml
+++ b/distributed/control-plane/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.5.0"
 description: A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 name: wso2am-acp
-version: 4.5.0-rc3
+version: 4.5.0-1
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/distributed/gateway/Chart.yaml
+++ b/distributed/gateway/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.5.0"
 description: A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 name: wso2am-universal-gw
-version: 4.5.0-rc3
+version: 4.5.0-1
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/distributed/key-manager/Chart.yaml
+++ b/distributed/key-manager/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.5.0"
 description: A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 name: wso2am-km
-version: 4.5.0-rc3
+version: 4.5.0-1
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/distributed/traffic-manager/Chart.yaml
+++ b/distributed/traffic-manager/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.5.0"
 description: A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 name: wso2am-tm
-version: 4.5.0-rc3
+version: 4.5.0-1
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg


### PR DESCRIPTION
This pull request includes version updates across multiple Helm chart files to reflect the new release version `4.5.0-1`. The most important changes include updating the version field in various `Chart.yaml` files.

Version updates:

* [`all-in-one/Chart.yaml`](diffhunk://#diff-a7ec70fc7271b0e56e22e3998aad8bf069f7063593493fdde4bff80d72ab466dL16-R16): Updated version from `4.5.0-rc3` to `4.5.0-1`.
* [`distributed/control-plane/Chart.yaml`](diffhunk://#diff-e127b064f30eca4ea05fe9d42dc2a066a75a7e197b2f6a9f03b0c589f53e8fa7L16-R16): Updated version from `4.5.0-rc3` to `4.5.0-1`.
* [`distributed/gateway/Chart.yaml`](diffhunk://#diff-61c47019dcea9d644fbe1b55787c9caa4d79853f86d42d50b31c12fa8dced209L16-R16): Updated version from `4.5.0-rc3` to `4.5.0-1`.
* [`distributed/key-manager/Chart.yaml`](diffhunk://#diff-35824ece04d30f4db31c4cf215c0ca7a122dee96cc67550845bfc7d347579db2L16-R16): Updated version from `4.5.0-rc3` to `4.5.0-1`.
* [`distributed/traffic-manager/Chart.yaml`](diffhunk://#diff-1362ae3919f49ac5c07460d0aed43907e8336677290eaafb21f1db899b96fc41L16-R16): Updated version from `4.5.0-rc3` to `4.5.0-1`.