### PR TITLE
Support private docker registries

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -134,7 +134,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.apim.configurations.eventListeners[0].order | int | `1` |  |
 | wso2.apim.configurations.eventListeners[0].properties.notificationEndpoint | string | `"https://localhost:${mgt.transport.https.port}/internal/data/v1/notify"` |  |
 | wso2.apim.configurations.eventListeners[0].type | string | `"org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"` |  |
-| wso2.apim.configurations.gateway.environments | list | `[{"description":"This is a hybrid gateway that handles both production and sandbox token traffic.","displayInApiConsole":true,"gatewayType":"Regular","httpHostname":"gw.wso2.com","name":"Default","provider":"wso2","serviceName":"wso2am-gateway-service","servicePort":9443,"showAsTokenEndpointUrl":true,"type":"hybrid","websubHostname":"websub.wso2.com","wsHostname":"websocket.wso2.com"}]` | APIM Gateway environments |
+| wso2.apim.configurations.gateway.environments | list | `[{"description":"This is a hybrid gateway that handles both production and sandbox token traffic.","displayInApiConsole":true,"gatewayType":"Regular","httpHostname":"gw.wso2.com","name":"Default","provider":"wso2","serviceName":"wso2am-gateway-service","servicePort":9443,"showAsTokenEndpointUrl":true,"type":"hybrid","visibility":null,"websubHostname":"websub.wso2.com","wsHostname":"websocket.wso2.com"}]` | APIM Gateway environments |
 | wso2.apim.configurations.gatewayType | string | `"Regular,APK,AWS"` |  |
 | wso2.apim.configurations.governance.scheduler | object | `{"queue_size":"","task_check_interval_minutes":"","task_cleanup_interval_minutes":"","thread_pool_size":""}` | Override the default values of governance.scheduler if any value exists |
 | wso2.apim.configurations.iskm.enabled | bool | `false` |  |
@@ -164,6 +164,9 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.apim.configurations.oauth_config.oauth2JWKSUrl | string | `""` |  |
 | wso2.apim.configurations.oauth_config.removeOutboundAuthHeader | bool | `true` | Remove auth header from outgoing requests |
 | wso2.apim.configurations.oauth_config.revokeEndpoint | string | `""` | OAuth revoke endpoint |
+| wso2.apim.configurations.organization_based_access_control.enabled | bool | `true` |  |
+| wso2.apim.configurations.organization_based_access_control.organization_id_local_claim | string | `"http://wso2.org/claims/organizationId"` |  |
+| wso2.apim.configurations.organization_based_access_control.organization_name_local_claim | string | `"http://wso2.org/claims/organization"` |  |
 | wso2.apim.configurations.publisher.enablePortalConfigurationOnlyMode | bool | `false` |  |
 | wso2.apim.configurations.publisher.enable_api_doc_visibility | bool | `false` | Supported document types in Publisher.  This should be used only if there are additional document types to be supported. |
 | wso2.apim.configurations.publisher.internalKeyIssuer | string | `""` |  |
@@ -251,6 +254,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.apim.configurations.workflow.tokenEndpoint | string | `""` |  |
 | wso2.apim.log4j2.appenders | string | `""` | Appenders |
 | wso2.apim.log4j2.loggers | string | `""` | Console loggers that can be enabled. Allowed values are AUDIT_LOG_CONSOLE, HTTP_ACCESS_CONSOLE, TRANSACTION_CONSOLE, CORRELATION_CONSOLE |
+| wso2.apim.mountFrontendConfig | bool | `false` | Frontend settings.json mount status |
 | wso2.apim.mountStartupScript | bool | `false` | Startup script mount status |
 | wso2.apim.portOffset | int | `0` | Port Offset for APIM deployment |
 | wso2.apim.secureVaultEnabled | bool | `false` | Secure vauld enabled |
@@ -261,6 +265,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.choreoAnalytics.onpremKey | string | `""` | On-premise key for Choreo Analytics |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
 | wso2.deployment.image.registry | string | `""` | Registry containing the image |
 | wso2.deployment.image.repository | string | `""` | Repository name consisting the image |
 | wso2.deployment.lifecycle.preStopHook.sleepSeconds | int | `10` | Time to wait until the apim is terminated gracefully |

--- a/all-in-one/default_values.yaml
+++ b/all-in-one/default_values.yaml
@@ -577,6 +577,12 @@ wso2:
   deployment:
     # Container image configurations
     image:
+      # -- Container registry credentials.
+      # Specify image pull secrets for private registries
+      imagePullSecrets:
+        enabled: false
+        username: ""
+        password: ""
       # -- Registry containing the image
       registry: "docker.io"
       # -- Repository name consisting the image

--- a/all-in-one/templates/_helpers.tpl
+++ b/all-in-one/templates/_helpers.tpl
@@ -93,3 +93,8 @@ Check if all the governance.scheduler configuration values are empty.
     (empty $scheduler.task_cleanup_interval_minutes)
 -}}
 {{- end -}}
+
+{{- define "dockerconfigjson" -}}
+{{- $auth := printf "%s:%s" .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password | b64enc -}}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .Values.wso2.deployment.image.registry .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password $auth | b64enc -}}
+{{- end -}}

--- a/all-in-one/templates/am/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/wso2am-deployment.yaml
@@ -57,6 +57,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+      imagePullSecrets:
+      - name: {{ template "am-all-in-one.fullname" . }}-docker-registry-auth
+      {{- end }}
       containers:
         - name: wso2am
           image: {{ .Values.wso2.deployment.image.registry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}

--- a/all-in-one/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/all-in-one/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  creationTimestamp: null
+  name: {{ template "am-all-in-one.fullname" . }}-docker-registry-auth
+  namespace: {{ .Release.Namespace }}
+data:
+  .dockerconfigjson: {{ include "dockerconfigjson" . }}
+{{- end }}

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -577,6 +577,12 @@ wso2:
   deployment:
     # Container image configurations
     image:
+      # -- Container registry credentials.
+      # Specify image pull secrets for private registries
+      imagePullSecrets:
+        enabled: false
+        username: ""
+        password: ""
       # -- Registry containing the image
       registry: ""
       # -- Repository name consisting the image

--- a/distributed/control-plane/README.md
+++ b/distributed/control-plane/README.md
@@ -1,8 +1,8 @@
-# wso2am-cp
+# wso2am-acp
 
 ![Version: 4.5.0-1](https://img.shields.io/badge/Version-4.5.0--1-informational?style=flat-square) ![AppVersion: 4.5.0](https://img.shields.io/badge/AppVersion-4.5.0-informational?style=flat-square)
 
-A Helm chart for the deployment of WSO2 API Management Control Plane profile
+A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 
 ## Values
 
@@ -101,7 +101,7 @@ A Helm chart for the deployment of WSO2 API Management Control Plane profile
 | wso2.apim.configurations.devportal.enableKeyProvisioning | string | `nil` |  |
 | wso2.apim.configurations.devportal.enableRatings | string | `nil` |  |
 | wso2.apim.configurations.devportal.loginUsernameCaseInsensitive | string | `nil` |  |
-| wso2.apim.configurations.gateway.environments | list | `[{"description":"This is a hybrid gateway that handles both production and sandbox token traffic.","displayInApiConsole":true,"gatewayType":"Regular","httpHostname":"gw.wso2.com","name":"Default","provider":"wso2","serviceName":"wso2am-gateway-service","servicePort":9443,"showAsTokenEndpointUrl":true,"type":"hybrid","websubHostname":"websub.wso2.com","wsHostname":"websocket.wso2.com"}]` | APIM Gateway environments |
+| wso2.apim.configurations.gateway.environments | list | `[{"description":"This is a hybrid gateway that handles both production and sandbox token traffic.","displayInApiConsole":true,"gatewayType":"Regular","httpHostname":"gw.wso2.com","name":"Default","provider":"wso2","serviceName":"wso2am-gateway-service","servicePort":9443,"showAsTokenEndpointUrl":true,"type":"hybrid","visibility":null,"websubHostname":"websub.wso2.com","wsHostname":"websocket.wso2.com"}]` | APIM Gateway environments |
 | wso2.apim.configurations.gatewayType | string | `"Regular,APK,AWS"` |  |
 | wso2.apim.configurations.governance.scheduler | object | `{"queue_size":"","task_check_interval_minutes":"","task_cleanup_interval_minutes":"","thread_pool_size":""}` | Override the default values of governance.scheduler if any value exists |
 | wso2.apim.configurations.iskm.enabled | bool | `false` | If Identity Server is used as the Resident KM |
@@ -124,6 +124,9 @@ A Helm chart for the deployment of WSO2 API Management Control Plane profile
 | wso2.apim.configurations.openTracer.name | string | `""` | Remote tracer name. e.g. jaeger, zipkin |
 | wso2.apim.configurations.openTracer.properties.hostname | string | `""` | Remote tracer hostname |
 | wso2.apim.configurations.openTracer.properties.port | string | `""` | Remote tracer port |
+| wso2.apim.configurations.organization_based_access_control.enabled | bool | `true` |  |
+| wso2.apim.configurations.organization_based_access_control.organization_id_local_claim | string | `"http://wso2.org/claims/organizationId"` |  |
+| wso2.apim.configurations.organization_based_access_control.organization_name_local_claim | string | `"http://wso2.org/claims/organization"` |  |
 | wso2.apim.configurations.publisher.enablePortalConfigurationOnlyMode | bool | `false` |  |
 | wso2.apim.configurations.publisher.enable_api_doc_visibility | bool | `false` | Supported document types in Publisher.  This should be used only if there are additional document types to be supported. |
 | wso2.apim.configurations.publisher.internalKeyIssuer | string | `""` |  |
@@ -165,6 +168,7 @@ A Helm chart for the deployment of WSO2 API Management Control Plane profile
 | wso2.apim.configurations.userStore.type | string | `"database_unique_id"` | User store type.  https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/ |
 | wso2.apim.log4j2.appenders | string | `""` | Appenders |
 | wso2.apim.log4j2.loggers | string | `""` | Console loggers that can be enabled. Allowed values are AUDIT_LOG_CONSOLE, HTTP_ACCESS_CONSOLE, TRANSACTION_CONSOLE, CORRELATION_CONSOLE |
+| wso2.apim.mountFrontendConfig | bool | `false` | Frontend settings.json mount status |
 | wso2.apim.mountStartupScript | bool | `false` | Startup script mount status |
 | wso2.apim.portOffset | int | `0` | Port Offset for APIM deployment |
 | wso2.apim.secureVaultEnabled | bool | `false` | Secure vauld enabled |
@@ -173,6 +177,7 @@ A Helm chart for the deployment of WSO2 API Management Control Plane profile
 | wso2.deployment.highAvailability | bool | `true` | Enable high availability for traffic manager. If this is enabled, two traffic manager instances will be deployed. This is not relavant to HA in Kubernetes. Multiple replicas of the same instance will not count as HA for TM. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.lifecycle.preStopHook.sleepSeconds | int | `10` | Number of seconds to sleep before sending SIGTERM to the pod |

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -60,6 +60,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+      imagePullSecrets:
+        - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+      {{- end }}
       containers:
       - name: wso2am-control-plane
         image: {{ .Values.wso2.deployment.image.registry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
-        - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+      - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
       {{- end }}
       containers:
       - name: wso2am-control-plane

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -63,7 +63,7 @@ spec:
           type: RuntimeDefault
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
-        - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+      - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
       {{- end }}
       containers:
       - name: wso2am-control-plane

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -61,6 +61,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+      imagePullSecrets:
+        - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+      {{- end }}
       containers:
       - name: wso2am-control-plane
         image: {{ .Values.wso2.deployment.image.registry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}

--- a/distributed/control-plane/templates/secrets/_helpers.tpl
+++ b/distributed/control-plane/templates/secrets/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------s
+*/}}
+
+{{- define "dockerconfigjson" -}}
+{{- $auth := printf "%s:%s" .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password | b64enc -}}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .Values.wso2.deployment.image.registry .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password $auth | b64enc -}}
+{{- end -}}

--- a/distributed/control-plane/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/control-plane/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  creationTimestamp: null
+  name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+  namespace: {{ .Release.Namespace }}
+data:
+  .dockerconfigjson: {{ include "dockerconfigjson" . }}
+{{- end }}

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -416,6 +416,12 @@ wso2:
   deployment:
     # Container image configurations
     image:
+      # -- Container registry credentials.
+      # Specify image pull secrets for private registries
+      imagePullSecrets:
+        enabled: false
+        username: ""
+        password: ""
       # -- Container registry hostname
       registry: ""
       # -- Azure ACR repository name consisting the image

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -1,8 +1,8 @@
-# wso2am-gateway
+# wso2am-universal-gw
 
 ![Version: 4.5.0-1](https://img.shields.io/badge/Version-4.5.0--1-informational?style=flat-square) ![AppVersion: 4.5.0](https://img.shields.io/badge/AppVersion-4.5.0-informational?style=flat-square)
 
-A Helm chart for the deployment of WSO2 API Management Gateway profile
+A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 
 ## Values
 
@@ -142,6 +142,7 @@ A Helm chart for the deployment of WSO2 API Management Gateway profile
 | wso2.deployment.cpuUtilizationPercentage | int | `75` | Target CPU utilization percentage for HPA |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.lifecycle.preStopHook.sleepSeconds | int | `10` | Number of seconds to sleep before sending SIGTERM to the pod |

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -61,6 +61,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+      imagePullSecrets:
+      - name: {{ template "apim-helm-gw.fullname" . }}-docker-registry-auth
+      {{- end }}
       containers:
       - name: wso2am-gateway
         image: {{ .Values.wso2.deployment.image.registry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}

--- a/distributed/gateway/templates/secrets/_helpers.tpl
+++ b/distributed/gateway/templates/secrets/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------s
+*/}}
+
+{{- define "dockerconfigjson" -}}
+{{- $auth := printf "%s:%s" .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password | b64enc -}}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .Values.wso2.deployment.image.registry .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password $auth | b64enc -}}
+{{- end -}}

--- a/distributed/gateway/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/gateway/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  creationTimestamp: null
+  name: {{ template "apim-helm-gw.fullname" . }}-docker-registry-auth
+  namespace: {{ .Release.Namespace }}
+data:
+  .dockerconfigjson: {{ include "dockerconfigjson" . }}
+{{- end }}

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -379,6 +379,12 @@ wso2:
   deployment:
     # Container image configurations
     image:
+      # -- Container registry credentials.
+      # Specify image pull secrets for private registries
+      imagePullSecrets:
+        enabled: false
+        username: ""
+        password: ""
       # -- Container registry hostname
       registry: ""
       # -- Azure ACR repository name consisting the image

--- a/distributed/key-manager/README.md
+++ b/distributed/key-manager/README.md
@@ -102,6 +102,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.highAvailability | bool | `false` | Enable high availability for key manager. If this is enabled, two key manager replicas will be deployed. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.lifecycle.preStopHook.sleepSeconds | int | `10` | Number of seconds to sleep before sending SIGTERM to the pod |

--- a/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           type: RuntimeDefault
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
-      - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+      - name: {{ template "apim-helm-km.fullname" . }}-docker-registry-auth
       {{- end }}
       containers:
       - name: wso2am-km

--- a/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
@@ -65,6 +65,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+      imagePullSecrets:
+      - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+      {{- end }}
       containers:
       - name: wso2am-km
         image: {{ .Values.wso2.deployment.image.registry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}

--- a/distributed/key-manager/templates/secrets/_helpers.tpl
+++ b/distributed/key-manager/templates/secrets/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------s
+*/}}
+
+{{- define "dockerconfigjson" -}}
+{{- $auth := printf "%s:%s" .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password | b64enc -}}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .Values.wso2.deployment.image.registry .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password $auth | b64enc -}}
+{{- end -}}

--- a/distributed/key-manager/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/key-manager/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  creationTimestamp: null
+  name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+  namespace: {{ .Release.Namespace }}
+data:
+  .dockerconfigjson: {{ include "dockerconfigjson" . }}
+{{- end }}

--- a/distributed/key-manager/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/key-manager/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -15,7 +15,7 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   creationTimestamp: null
-  name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+  name: {{ template "apim-helm-km.fullname" . }}-docker-registry-auth
   namespace: {{ .Release.Namespace }}
 data:
   .dockerconfigjson: {{ include "dockerconfigjson" . }}

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -263,6 +263,12 @@ wso2:
   deployment:
     # Container image configurations
     image:
+      # -- Container registry credentials.
+      # Specify image pull secrets for private registries
+      imagePullSecrets:
+        enabled: false
+        username: ""
+        password: ""
       # -- Container registry hostname
       registry: ""
       # -- Azure ACR repository name consisting the image

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -97,6 +97,7 @@ A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 | wso2.deployment.highAvailability | bool | `true` | Enable high availability for traffic manager. If this is enabled, two traffic manager instances will be deployed. This is not relavant to HA in Kubernetes. Multiple replicas of the same instance will not count as HA for TM. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.lifecycle.preStopHook.sleepSeconds | int | `10` | Number of seconds to sleep before sending SIGTERM to the pod |

--- a/distributed/traffic-manager/templates/secrets/_helpers.tpl
+++ b/distributed/traffic-manager/templates/secrets/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------s
+*/}}
+
+{{- define "dockerconfigjson" -}}
+{{- $auth := printf "%s:%s" .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password | b64enc -}}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .Values.wso2.deployment.image.registry .Values.wso2.deployment.image.imagePullSecrets.username .Values.wso2.deployment.image.imagePullSecrets.password $auth | b64enc -}}
+{{- end -}}

--- a/distributed/traffic-manager/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/traffic-manager/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  creationTimestamp: null
+  name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
+  namespace: {{ .Release.Namespace }}
+data:
+  .dockerconfigjson: {{ include "dockerconfigjson" . }}
+{{- end }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -63,6 +63,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+      imagePullSecrets:
+      - name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
+      {{- end }}
       containers:
       - name: wso2am-traffic-manager
         image: {{ .Values.wso2.deployment.image.registry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -64,6 +64,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+      imagePullSecrets:
+      - name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
+      {{- end }}
       containers:
       - name: wso2am-traffic-manager
         image: {{ .Values.wso2.deployment.image.registry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -251,6 +251,12 @@ wso2:
   deployment:
     # Container image configurations
     image:
+      # -- Container registry credentials.
+      # Specify image pull secrets for private registries
+      imagePullSecrets:
+        enabled: false
+        username: ""
+        password: ""
       # -- Container registry hostname
       registry: ""
       # -- Azure ACR repository name consisting the image


### PR DESCRIPTION
## Purpose
Currently, Helm charts only support public Docker registries. If you want to use a private registry, you must make the necessary changes manually.

## Goals
With this PR, we introduce support for using private registries. Users only need to provide the username and password in the values.yaml file.

## Approach
Introduce a Docker secret to store the registry credentials and add imagePullSecrets to the deployment.