### PR TITLE
Add OAuth2 JWKS URL configuration to deployment.toml

### DIFF
--- a/distributed/control-plane/confs/instance-2/deployment.toml
+++ b/distributed/control-plane/confs/instance-2/deployment.toml
@@ -151,6 +151,11 @@ allow_refresh_tokens = true
 iat_validity_period = "1h"
 {{- end }}
 
+[oauth.endpoints]
+{{- if .Values.wso2.apim.configurations.oauth_config }}
+oauth2_jwks_url = "{{ .Values.wso2.apim.configurations.oauth_config.oauth2JWKSUrl }}"
+{{- end }}
+
 [apim.publisher]
 enable_api_doc_visibility = {{ .Values.wso2.apim.configurations.publisher.enable_api_doc_visibility }}
 {{- if .Values.wso2.apim.configurations.publisher.supportedDocumentTypes }}


### PR DESCRIPTION
## Purpose
This pull request added  a missing configuration update to enable dynamic OAuth2 JWKS URL support in the deployment settings for `instance-2`. The most important change is the addition of a new `[oauth.endpoints]` section in the `deployment.toml` file.

### Configuration Updates:

* [`distributed/control-plane/confs/instance-2/deployment.toml`](diffhunk://#diff-b560adb75858dee3c4e52294c985255acfff36968d77662bbfe90559b1e54b84R154-R158): Added a new `[oauth.endpoints]` section to support dynamic configuration of `oauth2_jwks_url`. This is conditionally set based on the presence of `oauth_config` in the Helm chart values (`.Values.wso2.apim.configurations.oauth_config`).