### PR TITLE
Set defaultAutoCommit to true in database pool parameters

### DIFF
--- a/all-in-one/default_values.yaml
+++ b/all-in-one/default_values.yaml
@@ -243,7 +243,7 @@ wso2:
           password: "wso2carbon"
           # -- APIM database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000
@@ -259,7 +259,7 @@ wso2:
           password: "wso2carbon"
           # -- APIM database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -243,7 +243,7 @@ wso2:
           password: ""
           # -- APIM database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000
@@ -259,7 +259,7 @@ wso2:
           password: ""
           # -- APIM database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -221,7 +221,7 @@ wso2:
           password: ""
           # -- APIM database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000
@@ -238,7 +238,7 @@ wso2:
           password: ""
           # -- APIM shared database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -174,7 +174,7 @@ wso2:
           password: ""
           # -- APIM database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -154,7 +154,7 @@ wso2:
           password: ""
           # -- APIM database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000
@@ -171,7 +171,7 @@ wso2:
           password: ""
           # -- APIM shared database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -132,7 +132,7 @@ wso2:
           password: ""
           # -- APIM database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000
@@ -149,7 +149,7 @@ wso2:
           password: ""
           # -- APIM shared database JDBC pool parameters
           poolParameters:
-            defaultAutoCommit: false
+            defaultAutoCommit: true
             testOnBorrow: true
             testWhileIdle: true
             validationInterval: 30000


### PR DESCRIPTION
As per our discussion with @tharindu1st,  we decided to set defaultAutoCommit to true, which is also the default value specified in default.json

This pull request updates the default value of the `defaultAutoCommit` parameter in multiple configuration files for WSO2 deployments. The change ensures that the `defaultAutoCommit` setting is enabled (`true`) for all relevant JDBC pool configurations across various deployment modes.

### Changes to WSO2 configuration files:

* **All-in-One Deployment:**
  - Updated `defaultAutoCommit` to `true` in `all-in-one/default_values.yaml`. [[1]](diffhunk://#diff-11bb799bf3d60d57a146fc9d2f6312cfd667ca174b154b1bd04436f99ef13483L246-R246) [[2]](diffhunk://#diff-11bb799bf3d60d57a146fc9d2f6312cfd667ca174b154b1bd04436f99ef13483L262-R262)
  - Updated `defaultAutoCommit` to `true` in `all-in-one/values.yaml`. [[1]](diffhunk://#diff-cc9c7da284ce800303dc095b01d60a28eac033083a106c1900c99b15e6baeac2L246-R246) [[2]](diffhunk://#diff-cc9c7da284ce800303dc095b01d60a28eac033083a106c1900c99b15e6baeac2L262-R262)

* **Distributed Deployment:**
  - **Control Plane:** Updated `defaultAutoCommit` to `true` for both APIM and shared database JDBC pool configurations in `distributed/control-plane/values.yaml`. [[1]](diffhunk://#diff-512bffea7969fbfad597f4f7d4240dd34e45f0578e2c3e90a8f34359e7fe1b77L224-R224) [[2]](diffhunk://#diff-512bffea7969fbfad597f4f7d4240dd34e45f0578e2c3e90a8f34359e7fe1b77L241-R241)
  - **Gateway:** Updated `defaultAutoCommit` to `true` in `distributed/gateway/values.yaml`.
  - **Key Manager:** Updated `defaultAutoCommit` to `true` for both APIM and shared database JDBC pool configurations in `distributed/key-manager/values.yaml`. [[1]](diffhunk://#diff-a86e2b5eba14c797df91dcbb2a0abd126c1cb6e23c930f7534a4cc73b5f49d19L157-R157) [[2]](diffhunk://#diff-a86e2b5eba14c797df91dcbb2a0abd126c1cb6e23c930f7534a4cc73b5f49d19L174-R174)
  - **Traffic Manager:** Updated `defaultAutoCommit` to `true` for both APIM and shared database JDBC pool configurations in `distributed/traffic-manager/values.yaml`. [[1]](diffhunk://#diff-0f1c259f678f227a69ef818715a578c208425f470ff6af2297328c40b1660dd4L135-R135) [[2]](diffhunk://#diff-0f1c259f678f227a69ef818715a578c208425f470ff6af2297328c40b1660dd4L152-R152)