### PR TITLE
Helm chart modification for openshift support 

### DIFF
--- a/all-in-one/default_values.yaml
+++ b/all-in-one/default_values.yaml
@@ -177,6 +177,19 @@ kubernetes:
     # -- User ID of the container
     runAsUser: 10001
     runAsGroup: 10001
+    # -- SELinux context for the container
+    seLinux:
+      enabled: false
+      level: ""
+    # -- Seccomp profile for the container
+    seccompProfile:
+      # -- Seccomp profile type(RuntimeDefault, Unconfined or Localhost)
+      type: RuntimeDefault
+      localhostProfile: ""
+  # -- Set UNIX permissions over the executable scripts
+  configMaps:
+    scripts:
+      defaultMode: "0407"
 
 
 wso2:  
@@ -412,7 +425,7 @@ wso2:
         enableTokenEncryption: false
         # -- Enable token hashing
         enableTokenHashing: false
-        oauth2JWKSUrl: ""
+        oauth2JWKSUrl: "http://localhost:9763/oauth2/jwks"
 
       # APIM Devportal configurations
       devportal:

--- a/all-in-one/templates/am/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/wso2am-deployment.yaml
@@ -56,7 +56,10 @@ spec:
       {{- end }}
       securityContext:
         seccompProfile:
-          type: RuntimeDefault
+          type: {{ .Values.kubernetes.securityContext.seccompProfile.type }}
+          {{- if eq .Values.kubernetes.securityContext.seccompProfile.type "Localhost" }}
+          localhostProfile: {{ .Values.kubernetes.securityContext.seccompProfile.localhostProfile }}
+          {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
       - name: {{ template "am-all-in-one.fullname" . }}-docker-registry-auth
@@ -119,9 +122,12 @@ spec:
             runAsGroup: {{ .Values.kubernetes.securityContext.runAsGroup }}
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            {{- if .Values.kubernetes.securityContext.seLinux.enabled }}
+            seLinuxOptions:
+              level: {{ .Values.kubernetes.securityContext.seLinux.level }}
+            {{- end }}
             capabilities:
-              drop:
-                - all
+              drop: ["ALL"]
           ports:
             - containerPort: 8280
               protocol: "TCP"
@@ -209,7 +215,7 @@ spec:
         - name: wso2am-entrypoint
           configMap:
             name: {{ template "am-all-in-one.fullname" . }}-conf-entrypoint
-            defaultMode: 0407
+            defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
         - name: wso2am-log4j2
           configMap:
             name: {{ template "am-all-in-one.fullname" . }}-conf-log4j2
@@ -218,7 +224,7 @@ spec:
         - name: wso2am-sh-conf
           configMap:
             name: {{ template "am-all-in-one.fullname" . }}-conf-sh
-            defaultMode: 0407
+            defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
         {{- end }}
         {{- if .Values.wso2.apim.mountFrontendConfig }}
         - name: wso2am-conf-admin-settings

--- a/all-in-one/templates/am/wso2am-gateway-ingress.yaml
+++ b/all-in-one/templates/am/wso2am-gateway-ingress.yaml
@@ -24,7 +24,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.kubernetes.ingress.gateway.hostname }}
-  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+    secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
   rules:
   - host: {{ .Values.kubernetes.ingress.gateway.hostname }}
     http:

--- a/all-in-one/templates/am/wso2am-ingress.yaml
+++ b/all-in-one/templates/am/wso2am-ingress.yaml
@@ -24,7 +24,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.kubernetes.ingress.management.hostname }}
-  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+    secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
   rules:
   - host: {{ .Values.kubernetes.ingress.management.hostname }}
     http:

--- a/all-in-one/templates/am/wso2am-websocket-ingress.yaml
+++ b/all-in-one/templates/am/wso2am-websocket-ingress.yaml
@@ -25,7 +25,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.kubernetes.ingress.websocket.hostname }}
-  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+    secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
   rules:
   - host: {{ .Values.kubernetes.ingress.websocket.hostname }}
     http:

--- a/all-in-one/templates/am/wso2am-websub-ingress.yaml
+++ b/all-in-one/templates/am/wso2am-websub-ingress.yaml
@@ -25,7 +25,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.kubernetes.ingress.websub.hostname }}
-  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+    secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
   rules:
   - host: {{ .Values.kubernetes.ingress.websub.hostname }}
     http:

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -177,6 +177,19 @@ kubernetes:
     # -- User ID of the container
     runAsUser: 10001
     runAsGroup: 10001
+    # -- SELinux context for the container
+    seLinux:
+      enabled: false
+      level: ""
+    # -- Seccomp profile for the container
+    seccompProfile:
+      # -- Seccomp profile type(RuntimeDefault, Unconfined or Localhost)
+      type: RuntimeDefault
+      localhostProfile: ""
+  # -- Set UNIX permissions over the executable scripts
+  configMaps:
+    scripts:
+      defaultMode: "0407"
 
 
 wso2:  

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -11,7 +11,7 @@
 
 aws:
   # -- If AWS is used as the cloud provider
-  enabled: true
+  enabled: false
   efs:
     # -- EFS capacity
     capacity: ""

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -59,7 +59,10 @@ spec:
       {{- end }}
       securityContext:
         seccompProfile:
-          type: RuntimeDefault
+          type: {{ .Values.kubernetes.securityContext.seccompProfile.type }}
+          {{- if eq .Values.kubernetes.securityContext.seccompProfile.type "Localhost" }}
+          localhostProfile: {{ .Values.kubernetes.securityContext.seccompProfile.localhostProfile }}
+          {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
       - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
@@ -123,9 +126,12 @@ spec:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          {{- if .Values.kubernetes.securityContext.seLinux.enabled }}
+          seLinuxOptions:
+            level: {{ .Values.kubernetes.securityContext.seLinux.level }}
+          {{- end }}
           capabilities:
-            drop:
-              - all
+            drop: ["ALL"]
         ports:
           - containerPort: {{ add 9763 .Values.wso2.apim.portOffset }}
             protocol: "TCP"
@@ -209,7 +215,7 @@ spec:
       - name: wso2am-control-plane-entrypoint
         configMap:
           name: {{ template "apim-helm-cp.fullname" . }}-conf-entrypoint
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       - name: wso2am-control-plane-log4j2
         configMap:
           name: {{ template "apim-helm-cp.fullname" . }}-conf-log4j2
@@ -218,7 +224,7 @@ spec:
       - name: wso2am-sh-conf
         configMap:
           name: {{ template "apim-helm-cp.fullname" . }}-conf-sh
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       {{- end }}
       {{- if .Values.wso2.apim.mountFrontendConfig }}
       - name: wso2am-conf-admin-settings

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -60,7 +60,10 @@ spec:
       {{- end }}
       securityContext:
         seccompProfile:
-          type: RuntimeDefault
+          type: {{ .Values.kubernetes.securityContext.seccompProfile.type }}
+          {{- if eq .Values.kubernetes.securityContext.seccompProfile.type "Localhost" }}
+          localhostProfile: {{ .Values.kubernetes.securityContext.seccompProfile.localhostProfile }}
+          {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
       - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
@@ -124,9 +127,12 @@ spec:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          {{- if .Values.kubernetes.securityContext.seLinux.enabled }}
+          seLinuxOptions:
+            level: {{ .Values.kubernetes.securityContext.seLinux.level }}
+          {{- end }}
           capabilities:
-            drop:
-              - all
+            drop: ["ALL"]
         ports:
           - containerPort: {{ add 9763 .Values.wso2.apim.portOffset }}
             protocol: "TCP"
@@ -210,7 +216,7 @@ spec:
       - name: wso2am-control-plane-entrypoint
         configMap:
           name: {{ template "apim-helm-cp.fullname" . }}-conf-entrypoint
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       - name: wso2am-control-plane-log4j2
         configMap:
           name: {{ template "apim-helm-cp.fullname" . }}-conf-log4j2
@@ -219,7 +225,7 @@ spec:
       - name: wso2am-sh-conf
         configMap:
           name: {{ template "apim-helm-cp.fullname" . }}-conf-sh
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       {{- end }}
       {{- if .Values.wso2.apim.mountFrontendConfig }}
       - name: wso2am-conf-admin-settings

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -11,7 +11,7 @@
 
 aws:
   # -- If AWS is used as the cloud provider
-  enabled: true
+  enabled: false
   efs:
     # -- EFS capacity
     capacity: ""
@@ -168,8 +168,21 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- SELinux context for the container
+    seLinux:
+      enabled: false
+      level: ""
+    # -- Seccomp profile for the container
+    seccompProfile:
+      # -- Seccomp profile type(RuntimeDefault, Unconfined or Localhost)
+      type: RuntimeDefault
+      localhostProfile: ""
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
+  # -- Set UNIX permissions over the executable scripts
+  configMaps:
+    scripts:
+      defaultMode: "0407"
 
 wso2:  
   apim:

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -60,7 +60,10 @@ spec:
       {{- end }}
       securityContext:
         seccompProfile:
-          type: RuntimeDefault
+          type: {{ .Values.kubernetes.securityContext.seccompProfile.type }}
+          {{- if eq .Values.kubernetes.securityContext.seccompProfile.type "Localhost" }}
+          localhostProfile: {{ .Values.kubernetes.securityContext.seccompProfile.localhostProfile }}
+          {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
       - name: {{ template "apim-helm-gw.fullname" . }}-docker-registry-auth
@@ -125,9 +128,12 @@ spec:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          {{- if .Values.kubernetes.securityContext.seLinux.enabled }}
+          seLinuxOptions:
+            level: {{ .Values.kubernetes.securityContext.seLinux.level }}
+          {{- end }}
           capabilities:
-            drop:
-              - all
+            drop: ["ALL"]
         ports:
         - containerPort: {{ add 8280 .Values.wso2.apim.portOffset }}
           protocol: TCP
@@ -198,7 +204,7 @@ spec:
       - name: wso2am-gateway-entrypoint
         configMap:
           name: {{ template "apim-helm-gw.fullname" . }}-conf-entrypoint
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       - name: wso2am-gateway-log4j2
         configMap:
           name: {{ template "apim-helm-gw.fullname" . }}-conf-log4j2
@@ -207,7 +213,7 @@ spec:
       - name: wso2am-sh-conf
         configMap:
           name: {{ template "apim-helm-gw.fullname" . }}-conf-sh
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       {{- end }}
       {{- if .Values.wso2.apim.secureVaultEnabled }}
       - name: wso2am-gateway-secret-conf

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -11,7 +11,7 @@
 
 aws:
   # -- If AWS is used as the cloud provider
-  enabled: true
+  enabled: false
   # -- AWS region
   region: ""
   secretsManager:
@@ -110,8 +110,21 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- SELinux context for the container
+    seLinux:
+      enabled: false
+      level: ""
+    # -- Seccomp profile for the container
+    seccompProfile:
+      # -- Seccomp profile type(RuntimeDefault, Unconfined or Localhost)
+      type: RuntimeDefault
+      localhostProfile: ""
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
+  # -- Set UNIX permissions over the executable scripts
+  configMaps:
+    scripts:
+      defaultMode: "0407"
 
 wso2:  
   # -- WSO2 Choreo Analytics Parameters

--- a/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
@@ -64,7 +64,10 @@ spec:
       {{- end }}
       securityContext:
         seccompProfile:
-          type: RuntimeDefault
+          type: {{ .Values.kubernetes.securityContext.seccompProfile.type }}
+          {{- if eq .Values.kubernetes.securityContext.seccompProfile.type "Localhost" }}
+          localhostProfile: {{ .Values.kubernetes.securityContext.seccompProfile.localhostProfile }}
+          {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
       - name: {{ template "apim-helm-km.fullname" . }}-docker-registry-auth
@@ -119,9 +122,12 @@ spec:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          {{- if .Values.kubernetes.securityContext.seLinux.enabled }}
+          seLinuxOptions:
+            level: {{ .Values.kubernetes.securityContext.seLinux.level }}
+          {{- end }}
           capabilities:
-            drop:
-              - all
+            drop: ["ALL"]
         ports:
         - containerPort: {{ add 9763 .Values.wso2.apim.portOffset }}
           protocol: TCP
@@ -180,7 +186,7 @@ spec:
       - name: wso2am-km-entrypoint
         configMap:
           name: {{ template "apim-helm-km.fullname" . }}-conf-entrypoint
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       - name: wso2am-km-log4j2
         configMap:
           name: {{ template "apim-helm-km.fullname" . }}-conf-log4j2
@@ -189,7 +195,7 @@ spec:
       - name: wso2am-sh-conf
         configMap:
           name: {{ template "apim-helm-km.fullname" . }}-conf-sh
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       {{- end }}
       {{- if .Values.wso2.apim.secureVaultEnabled }}
       - name: wso2am-km-secret-conf

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -104,8 +104,21 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- SELinux context for the container
+    seLinux:
+      enabled: false
+      level: ""
+    # -- Seccomp profile for the container
+    seccompProfile:
+      # -- Seccomp profile type(RuntimeDefault, Unconfined or Localhost)
+      type: RuntimeDefault
+      localhostProfile: ""
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
+  # -- Set UNIX permissions over the executable scripts
+  configMaps:
+    scripts:
+      defaultMode: "0407"
 
 wso2:  
   apim:

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -62,7 +62,10 @@ spec:
       {{- end }}
       securityContext:
         seccompProfile:
-          type: RuntimeDefault
+          type: {{ .Values.kubernetes.securityContext.seccompProfile.type }}
+          {{- if eq .Values.kubernetes.securityContext.seccompProfile.type "Localhost" }}
+          localhostProfile: {{ .Values.kubernetes.securityContext.seccompProfile.localhostProfile }}
+          {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
       - name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
@@ -126,9 +129,12 @@ spec:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          {{- if .Values.kubernetes.securityContext.seLinux.enabled }}
+          seLinuxOptions:
+            level: {{ .Values.kubernetes.securityContext.seLinux.level }}
+          {{- end }}
           capabilities:
-            drop:
-              - all
+            drop: ["ALL"]
         ports:
           - containerPort: 9763
             protocol: "TCP"
@@ -193,7 +199,7 @@ spec:
       - name: wso2am-traffic-manager-entrypoint
         configMap:
           name: {{ template "apim-helm-tm.fullname" . }}-conf-entrypoint
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       - name: wso2am-traffic-manager-log4j2
         configMap:
           name: {{ template "apim-helm-tm.fullname" . }}-conf-log4j2
@@ -202,7 +208,7 @@ spec:
       - name: wso2am-sh-conf
         configMap:
           name: {{ template "apim-helm-tm.fullname" . }}-conf-sh
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       {{- end }}
       {{- if .Values.wso2.apim.secureVaultEnabled }}
       - name: wso2am-traffic-manager-secret-conf

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -63,7 +63,10 @@ spec:
       {{- end }}
       securityContext:
         seccompProfile:
-          type: RuntimeDefault
+          type: {{ .Values.kubernetes.securityContext.seccompProfile.type }}
+          {{- if eq .Values.kubernetes.securityContext.seccompProfile.type "Localhost" }}
+          localhostProfile: {{ .Values.kubernetes.securityContext.seccompProfile.localhostProfile }}
+          {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
       - name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
@@ -127,9 +130,12 @@ spec:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          {{- if .Values.kubernetes.securityContext.seLinux.enabled }}
+          seLinuxOptions:
+            level: {{ .Values.kubernetes.securityContext.seLinux.level }}
+          {{- end }}
           capabilities:
-            drop:
-              - all
+            drop: ["ALL"]
         ports:
           - containerPort: 9763
             protocol: "TCP"
@@ -194,7 +200,7 @@ spec:
       - name: wso2am-traffic-manager-entrypoint
         configMap:
           name: {{ template "apim-helm-tm.fullname" . }}-conf-entrypoint
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       - name: wso2am-traffic-manager-log4j2
         configMap:
           name: {{ template "apim-helm-tm.fullname" . }}-conf-log4j2
@@ -203,7 +209,7 @@ spec:
       - name: wso2am-sh-conf
         configMap:
           name: {{ template "apim-helm-tm.fullname" . }}-conf-sh
-          defaultMode: 0407
+          defaultMode: {{ .Values.kubernetes.configMaps.scripts.defaultMode }}
       {{- end }}
       {{- if .Values.wso2.apim.secureVaultEnabled }}
       - name: wso2am-traffic-manager-secret-conf

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -11,7 +11,7 @@
 
 aws:
   # -- If AWS is used as the cloud provider
-  enabled: true
+  enabled: false
   ecr:
     # -- AWS Elastic Container Registry name
     registry: ""
@@ -84,8 +84,21 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- SELinux context for the container
+    seLinux:
+      enabled: false
+      level: ""
+    # -- Seccomp profile for the container
+    seccompProfile:
+      # -- Seccomp profile type(RuntimeDefault, Unconfined or Localhost)
+      type: RuntimeDefault
+      localhostProfile: ""
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
+  # -- Set UNIX permissions over the executable scripts
+  configMaps:
+    scripts:
+      defaultMode: "0407"
 
 wso2:  
   apim:


### PR DESCRIPTION
## Purpose
> Add OpenShift support for APIM helm charts
> Related issues: 
>  - https://github.com/wso2-enterprise/apim-product-management/issues/103#issue-2862252895
>  - https://github.com/wso2-enterprise/wso2-apim-internal/issues/9515 

## Goals
> Currently, deploying the WSO2 APIM in Openshift environment is not supported. Hence users should be able to deploy APIM in OpenShift using the modified helm charts

## Approach

> 1. runAsUser: For allowing the assignment of arbitrary UIDs, you can set runAsUser as follows kubernetes.securityContext.runAsUser=null
> 2. seLinux Support: If you need SELinux support, you can enable it by setting kubernetes.securityContext.seLinux.enabled=true
> 3. AppArmor Support: If you need AppArmor disabled, you can do so by setting kubernetes.enableAppArmor=false
> 4. ConfigMap Access: If your runtime user doesn't have execute access to ConfigMaps, you can fix it by setting kubernetes.configMaps.scripts.defaultMode=0457
> 5. Seccomp: If you need to change which seccomp (secure computing mode) profile to apply, you can do it using
kubernetes.securityContext.seccompProfile.type