### PR TITLE
Rename Kubernetes secret from 'jks-secret' to 'apim-keystore-secret' 

### DIFF
--- a/docs/am-pattern-0-all-in-one/README.md
+++ b/docs/am-pattern-0-all-in-one/README.md
@@ -103,7 +103,7 @@ In addition to the primary, internal keystores and truststore files, you can als
 - Refer the following sample command to create the secret and use it in the APIM.
   
   ```
-  kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
+  kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
   ```
 > By default, this deployment uses the default keystores and truststores provided by the relevant WSO2 product.
 > For advanced details with regards to managing custom Java keystores and truststores in a container based WSO2 product deployment

--- a/docs/am-pattern-1-all-in-one-HA/README.md
+++ b/docs/am-pattern-1-all-in-one-HA/README.md
@@ -168,7 +168,7 @@ It is recommended to use the [**NGINX Ingress Controller**](https://kubernetes.g
 - Refer to the following sample command to create the secret and use it in the APIM:
   
   ```
-  kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
+  kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
   ```
 > By default, this deployment uses the default keystores and truststores provided by the relevant WSO2 product.
 > For advanced details regarding managing custom Java keystores and truststores in a container-based WSO2 product deployment,

--- a/docs/am-pattern-2-all-in-one_GW/README.md
+++ b/docs/am-pattern-2-all-in-one_GW/README.md
@@ -138,7 +138,7 @@ This document provides comprehensive instructions for deploying WSO2 API Manager
 - We have provided pre-configured YAML files to help you quickly start the deployment. You can use these files as a starting point to deploy this pattern. This deployment requires separate databases. Therefore, follow the steps in [2. Build Docker Images](#2-build-docker-images) to build the Docker images with JDBC drivers, and refer to [3. Configure Database](#3-configure-database) to set up the database.
 - Follow the steps in [1.2 Mount Keystore and Truststore](#12-mount-keystore-and-truststore) to create the truststore and keystore. If you want to use the WSO2 default keystore and truststore, you can find them in the `repository/resources/security` directory of the product pack. Navigate to this location and run the following command to create the secret:
 ```bash
-kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
+kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
 ```
 - Run the following command to deploy the Helm charts:
 > **Important:** Naming conventions are important. If you want to change them, ensure consistency. 
@@ -201,7 +201,7 @@ In addition to the primary, internal keystores and truststore files, you can als
 - Refer to the following sample command to create the secret and use it in the APIM.
   
   ```
-  kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
+  kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
   ```
 > By default, this deployment uses the default keystores and truststores provided by the relevant WSO2 product.
 > For advanced details regarding managing custom Java keystores and truststores in a container-based WSO2 product deployment,

--- a/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+++ b/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
@@ -449,7 +449,7 @@ wso2:
     # -- Minimum replicas for HPA
     minReplicas: 1
     # -- Maximum replicas for HPA
-    maxReplicas: 1
+    maxReplicas: 3
     # -- Target CPU utilization percentage for HPA
     cpuUtilizationPercentage: 75
     # -- Target memory utilization percentage for HPA

--- a/docs/am-pattern-2-all-in-one_GW/default_values.yaml
+++ b/docs/am-pattern-2-all-in-one_GW/default_values.yaml
@@ -278,7 +278,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-3-ACP_TM_GW/README.md
+++ b/docs/am-pattern-3-ACP_TM_GW/README.md
@@ -152,7 +152,7 @@ This document provides comprehensive instructions for deploying WSO2 API Manager
 - We have provided pre-configured YAML files to help you quickly start the deployment. You can use these files as a starting point to deploy this pattern. This deployment requires separate databases. Therefore, follow the steps in [2. Build Docker Images](#2-build-docker-images) to build the Docker images with JDBC drivers, and refer to [3. Configure Database](#3-configure-database) to set up the database.
 - Follow the steps in [1.2 Mount Keystore and Truststore](#12-mount-keystore-and-truststore) to create the truststore and keystore. If you want to use the WSO2 default keystore and truststore, you can find them in the `repository/resources/security` directory of the product pack. Navigate to this location and run the following command to create the secret:
 ```bash
-kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
+kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
 ```
 - Run the following command to deploy the Helm charts:
 > **Important:** Naming conventions are important. If you want to change them, ensure consistency. 
@@ -220,7 +220,7 @@ The recommendation is to use the [**NGINX Ingress Controller**](https://kubernet
 - Refer to the following sample command to create the secret and use it in the APIM.
   
   ```
-  kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
+  kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
   ```
 > By default, this deployment uses the default keystores and truststores provided by the relevant WSO2 product.
 > For advanced details regarding managing custom Java keystores and truststores in a container-based WSO2 product deployment,

--- a/docs/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
+++ b/docs/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
@@ -254,7 +254,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+++ b/docs/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
@@ -190,7 +190,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
+++ b/docs/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
@@ -159,7 +159,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-4-ACP_TM_GW_KM/README.md
+++ b/docs/am-pattern-4-ACP_TM_GW_KM/README.md
@@ -164,7 +164,7 @@ This document provides comprehensive instructions for deploying WSO2 API Manager
 - We have provided pre-configured YAML files to help you quickly start the deployment. You can use this file as a starting point to deploy this pattern. This deployment requires separate databases. Therefore, follow the steps in [2. Build Docker Images](#2-build-docker-images) to build the Docker images with JDBC drivers, and refer to [3. Configure Database](#3-configure-database) to set up the database.
 - Follow the steps in [1.2 Mount Keystore and Truststore](#12-mount-keystore-and-truststore) to create the truststore and keystore. If you want to use the WSO2 default keystore and truststore, you can find them in the `repository/resources/security` directory of the product pack. Navigate to this location and run the following command to create the secret:
 ```bash
-kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
+kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
 ```
 - Run the following command to deploy the Helm charts:
 > **Important:** Naming conventions are important. If you want to change them, ensure consistency. 
@@ -238,7 +238,7 @@ In addition to the primary, internal keystores and truststore files, you can als
 - Refer to the following sample command to create the secret and use it in the APIM.
   
   ```
-  kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
+  kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
   ```
 > By default, this deployment uses the default keystores and truststores provided by the relevant WSO2 product.
 > For advanced details with regards to managing custom Java keystores and truststores in a container-based WSO2 product deployment

--- a/docs/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
+++ b/docs/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
@@ -254,7 +254,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+++ b/docs/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
@@ -190,7 +190,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
+++ b/docs/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
@@ -181,7 +181,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
+++ b/docs/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
@@ -159,7 +159,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-5-all-in-one_GW_KM/README.md
+++ b/docs/am-pattern-5-all-in-one_GW_KM/README.md
@@ -155,7 +155,7 @@ This document provides comprehensive instructions for deploying WSO2 API Manager
 - We have provided pre-configured YAML files to help you quickly start the deployment. You can use these files as a starting point to deploy this pattern. This deployment requires separate databases. Therefore, follow the steps in [2. Build Docker Images](#2-build-docker-images) to build the Docker images with JDBC drivers, and refer to [3. Configure Database](#3-configure-database) to set up the database.
 - Follow the steps in [1.2 Mount Keystore and Truststore](#12-mount-keystore-and-truststore) to create the truststore and keystore. If you want to use the WSO2 default keystore and truststore, you can find them in the `repository/resources/security` directory of the product pack. Navigate to this location and run the following command to create the secret:
 ```bash
-kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
+kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
 ```
 - Run the following command to deploy the Helm charts:
 > **Important:** Naming conventions are important. If you want to change them, ensure consistency. 
@@ -223,7 +223,7 @@ In addition to the primary, internal keystores and truststore files, you can als
 - Refer to the following sample command to create the secret and use it in the APIM.
   
   ```
-  kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
+  kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks --from-file=wso2internal.jks -n <namespace>
   ```
 > By default, this deployment uses the default keystores and truststores provided by the relevant WSO2 product.
 > For advanced details regarding managing custom Java keystores and truststores in a container-based WSO2 product deployment,

--- a/docs/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
+++ b/docs/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
@@ -181,7 +181,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml
+++ b/docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml
@@ -278,7 +278,7 @@ wso2:
 
       security:
         # -- Kubernetes secret containing the keystores and truststore
-        jksSecretName: "jks-secret"
+        jksSecretName: "apim-keystore-secret"
         keystores:
           primary:
             # -- Primary keystore enabled

--- a/docs/openshift_deployment.md
+++ b/docs/openshift_deployment.md
@@ -69,7 +69,7 @@ oc login <API server URL> -u <user> -p <password>
 1. Before deploying the Helm chart, we need to create a Kubernetes secret containing the keystores and truststore.
 2. You can find the default keystore and truststore in the following location within any of the APIM packs: `repository/resources/security/`
 ```bash
-kubectl create secret generic jks-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
+kubectl create secret generic apim-keystore-secret --from-file=wso2carbon.jks --from-file=client-truststore.jks
 ```
 
 #### Clone helm-apim


### PR DESCRIPTION
## Purpose 
To rename the `jksSecret` for consistency across all documentation.