### PR TITLE
[4.4.x] Add Km service port

### DIFF
--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -1,6 +1,6 @@
 # wso2am-gateway
 
-![Version: 4.4.0-2](https://img.shields.io/badge/Version-4.4.0--1-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
+![Version: 4.4.0-2](https://img.shields.io/badge/Version-4.4.0--2-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
 
 A Helm chart for the deployment of WSO2 API Management Gateway profile
 
@@ -84,6 +84,7 @@ A Helm chart for the deployment of WSO2 API Management Gateway profile
 | wso2.apim.configurations.jwt.generatorImpl | string | `"org.wso2.carbon.apimgt.keymgt.token.JWTGenerator"` |  |
 | wso2.apim.configurations.jwt.header | string | `"X-JWT-Assertion"` |  |
 | wso2.apim.configurations.jwt.signingAlgorithm | string | `"SHA256withRSA"` |  |
+| wso2.apim.configurations.km.servicePort | int | `9443` | Key Manager service port |
 | wso2.apim.configurations.km.serviceUrl | string | `"wso2am-cp-service"` | Key manager service name if default Resident KM is used |
 | wso2.apim.configurations.oauth_config.authHeader | string | `"Authorization"` | OAuth authorization header name |
 | wso2.apim.configurations.oauth_config.enableTokenEncryption | bool | `false` | Enable token encryption |

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -234,6 +234,8 @@ wso2:
       km:
         # -- Key manager service name if default Resident KM is used
         serviceUrl: "wso2am-cp-service"
+        # -- Key Manager service port
+        servicePort: 9443
 
       iskm:
         # If Identity Server is used as the Resident KM

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -1,6 +1,6 @@
 # wso2am-tm
 
-![Version: 4.4.0-2](https://img.shields.io/badge/Version-4.4.0--1-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
+![Version: 4.4.0-2](https://img.shields.io/badge/Version-4.4.0--2-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
 
 A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 
@@ -56,6 +56,7 @@ A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 | wso2.apim.configurations.eventhub.urls | list | `["wso2am-cp-1-service","wso2am-cp-2-service"]` | Event hub service urls |
 | wso2.apim.configurations.iskm.enabled | bool | `false` |  |
 | wso2.apim.configurations.iskm.serviceName | string | `""` |  |
+| wso2.apim.configurations.km.servicePort | int | `9443` | Key Manager service port |
 | wso2.apim.configurations.km.serviceUrl | string | `"wso2am-cp-service"` | Key manager service name if default Resident KM is used |
 | wso2.apim.configurations.oauth_config.enableTokenEncryption | bool | `false` | Enable token encryption |
 | wso2.apim.configurations.oauth_config.enableTokenHashing | bool | `false` | Enable token hashing |

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -203,6 +203,8 @@ wso2:
       km:
         # -- Key manager service name if default Resident KM is used
         serviceUrl: "wso2am-cp-service"
+        # -- Key Manager service port
+        servicePort: 9443
 
       iskm:
         # If Identity Server is used as the Resident KM

--- a/docs/am-pattern-2-all-in-one_gw/default_gw_values.yaml
+++ b/docs/am-pattern-2-all-in-one_gw/default_gw_values.yaml
@@ -231,6 +231,8 @@ wso2:
       km:
         # -- Key manager service name if default Resident KM is used
         serviceUrl: "apim-wso2am-all-in-one-am-service"
+        # -- Key Manager service port
+        servicePort: 9443        
 
       iskm:
         # If Identity Server is used as the Resident KM

--- a/docs/am-pattern-3-acp-tm-gw/default_gw_values.yaml
+++ b/docs/am-pattern-3-acp-tm-gw/default_gw_values.yaml
@@ -230,7 +230,9 @@ wso2:
 
       km:
         # -- Key manager service name if default Resident KM is used
-        serviceUrl: "apim-acp-wso2am-cp-service"
+        serviceUrl: "apim-acp-wso2am-acp-service"
+        # -- Key Manager service port
+        servicePort: 9443        
 
       iskm:
         # If Identity Server is used as the Resident KM

--- a/docs/am-pattern-3-acp-tm-gw/default_tm_values.yaml
+++ b/docs/am-pattern-3-acp-tm-gw/default_tm_values.yaml
@@ -199,7 +199,9 @@ wso2:
 
       km:
         # -- Key manager service name if default Resident KM is used
-        serviceUrl: "apim-acp-wso2am-cp-service"
+        serviceUrl: "apim-acp-wso2am-acp-service"
+        # -- Key Manager service port
+        servicePort: 9443        
 
       iskm:
         # If Identity Server is used as the Resident KM

--- a/docs/am-pattern-4-acp-tm-gw-km/default_gw_values.yaml
+++ b/docs/am-pattern-4-acp-tm-gw-km/default_gw_values.yaml
@@ -231,6 +231,8 @@ wso2:
       km:
         # -- Key manager service name if default Resident KM is used
         serviceUrl: "apim-km-wso2am-km-service"
+        # -- Key Manager service port
+        servicePort: 9443        
 
       iskm:
         # If Identity Server is used as the Resident KM

--- a/docs/am-pattern-4-acp-tm-gw-km/default_tm_values.yaml
+++ b/docs/am-pattern-4-acp-tm-gw-km/default_tm_values.yaml
@@ -200,6 +200,8 @@ wso2:
       km:
         # -- Key manager service name if default Resident KM is used
         serviceUrl: "apim-km-wso2am-km-service"
+        # -- Key Manager service port
+        servicePort: 9443        
 
       iskm:
         # If Identity Server is used as the Resident KM

--- a/docs/am-pattern-5-all-in-one-gw-km/default_gw_values.yaml
+++ b/docs/am-pattern-5-all-in-one-gw-km/default_gw_values.yaml
@@ -234,6 +234,8 @@ wso2:
       km:
         # -- Key manager service name if default Resident KM is used
         serviceUrl: "apim-km-wso2am-km-service"
+        # -- Key Manager service port
+        servicePort: 9443        
 
       iskm:
         # If Identity Server is used as the Resident KM


### PR DESCRIPTION
## Purpose
- Related to wso2-enterprise/wso2-apim-internal#10176
- Add Km service port. Currently the service port is missing.
- Update docs accordingly.