### PR TITLE
Add missig ai configuration in deployment.toml

### DIFF
--- a/all-in-one/confs/instance-1/deployment.toml
+++ b/all-in-one/confs/instance-1/deployment.toml
@@ -181,6 +181,8 @@ enable = false
 enable = true
 token = {{ .Values.wso2.apim.configurations.ai.token | quote }}
 endpoint = {{ .Values.wso2.apim.configurations.ai.endpoint | quote }}
+token_endpoint = {{ .Values.wso2.apim.configurations.ai.token_endpoint | quote }}
+key = {{ .Values.wso2.apim.configurations.ai.key | quote }}
 {{- else }}
 enable = false
 {{- end }}

--- a/all-in-one/confs/instance-2/deployment.toml
+++ b/all-in-one/confs/instance-2/deployment.toml
@@ -181,6 +181,8 @@ enable = false
 enable = true
 token = {{ .Values.wso2.apim.configurations.ai.token | quote }}
 endpoint = {{ .Values.wso2.apim.configurations.ai.endpoint | quote }}
+token_endpoint = {{ .Values.wso2.apim.configurations.ai.token_endpoint | quote }}
+key = {{ .Values.wso2.apim.configurations.ai.key | quote }}
 {{- else }}
 enable = false
 {{- end }}


### PR DESCRIPTION
This pull request updates the AI configuration sections in the deployment configuration files for both instance-1 and instance-2. The main change is the addition of two new configuration parameters: `token_endpoint` and `key` which is already available in the values.yaml.

Configuration enhancements:

* Added `token_endpoint` and `key` parameters to the AI configuration block in `all-in-one/confs/instance-1/deployment.toml`
* Added `token_endpoint` and `key` parameters to the AI configuration block in `all-in-one/confs/instance-2/deployment.toml`