### PR TITLE
Add new gateway types for default values.yaml files

### DIFF
--- a/all-in-one/default_openshift_values.yaml
+++ b/all-in-one/default_openshift_values.yaml
@@ -228,7 +228,7 @@ wso2:
     mountFrontendConfig: false
     # TOML configurations
     configurations:
-      gatewayType: "Regular,APK,AWS"
+      gatewayType: "Regular,APK,AWS,Azure,Kong"
       userStore:
         # -- User store type. 
         # https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/

--- a/docs/am-pattern-0-all-in-one/default_values.yaml
+++ b/docs/am-pattern-0-all-in-one/default_values.yaml
@@ -215,7 +215,7 @@ wso2:
     mountFrontendConfig: false
     # TOML configurations
     configurations:
-      gatewayType: "Regular,APK,AWS"
+      gatewayType: "Regular,APK,AWS,Azure,Kong"
       userStore:
         # -- User store type. 
         # https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/

--- a/docs/am-pattern-1-all-in-one-HA/default_values.yaml
+++ b/docs/am-pattern-1-all-in-one-HA/default_values.yaml
@@ -228,7 +228,7 @@ wso2:
     mountFrontendConfig: false
     # TOML configurations
     configurations:
-      gatewayType: "Regular,APK,AWS"
+      gatewayType: "Regular,APK,AWS,Azure,Kong"
       userStore:
         # -- User store type. 
         # https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/

--- a/docs/am-pattern-2-all-in-one_GW/default_values.yaml
+++ b/docs/am-pattern-2-all-in-one_GW/default_values.yaml
@@ -215,7 +215,7 @@ wso2:
     mountFrontendConfig: false
     # TOML configurations
     configurations:
-      gatewayType: "Regular,APK,AWS"
+      gatewayType: "Regular,APK,AWS,Azure,Kong"
       userStore:
         # -- User store type. 
         # https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/

--- a/docs/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
+++ b/docs/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
@@ -193,7 +193,7 @@ wso2:
     mountFrontendConfig: true
     # TOML configurations
     configurations:
-      gatewayType: "Regular,APK,AWS"
+      gatewayType: "Regular,APK,AWS,Azure,Kong"
       userStore:
         # -- User store type. 
         # https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/

--- a/docs/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
+++ b/docs/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
@@ -193,7 +193,7 @@ wso2:
     mountFrontendConfig: true
     # TOML configurations
     configurations:
-      gatewayType: "Regular,APK,AWS"
+      gatewayType: "Regular,APK,AWS,Azure,Kong"
       userStore:
         # -- User store type. 
         # https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/

--- a/docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml
+++ b/docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml
@@ -215,7 +215,7 @@ wso2:
     mountFrontendConfig: false
     # TOML configurations
     configurations:
-      gatewayType: "Regular,APK,AWS"
+      gatewayType: "Regular,APK,AWS,Azure,Kong"
       userStore:
         # -- User store type. 
         # https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/


### PR DESCRIPTION
## Purpose

This pull request adds support for two new gateway types, `Azure` and `Kong`, across all relevant configuration files. This change expands the list of supported gateway types from `Regular,APK,AWS` to `Regular,APK,AWS,Azure,Kong`, ensuring consistency for all deployment patterns.

Gateway type configuration updates:

* Updated the `gatewayType` configuration to include `Azure` and `Kong` in `all-in-one/default_openshift_values.yaml`.
* Updated the `gatewayType` configuration to include `Azure` and `Kong` in `docs/am-pattern-0-all-in-one/default_values.yaml`.
* Updated the `gatewayType` configuration to include `Azure` and `Kong` in `docs/am-pattern-1-all-in-one-HA/default_values.yaml`.
* Updated the `gatewayType` configuration to include `Azure` and `Kong` in `docs/am-pattern-2-all-in-one_GW/default_values.yaml`.
* Updated the `gatewayType` configuration to include `Azure` and `Kong` in `docs/am-pattern-3-ACP_TM_GW/default_acp_values.yaml`.
* Updated the `gatewayType` configuration to include `Azure` and `Kong` in `docs/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml`.
* Updated the `gatewayType` configuration to include `Azure` and `Kong` in `docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml`.