### PR TITLE
[APIM 4.6.0] Add websockets for the all-in-one service

### DIFF
--- a/all-in-one/templates/am/instance-1/wso2am-service.yaml
+++ b/all-in-one/templates/am/instance-1/wso2am-service.yaml
@@ -45,3 +45,9 @@ spec:
     - name: websub-https
       protocol: TCP
       port: 8021
+    - name: websocket-https
+      protocol: TCP
+      port: 8099
+    - name: websocket-http
+      protocol: TCP
+      port: 9099

--- a/all-in-one/templates/am/instance-2/wso2am-service.yaml
+++ b/all-in-one/templates/am/instance-2/wso2am-service.yaml
@@ -46,4 +46,10 @@ spec:
     - name: websub-https
       protocol: TCP
       port: 8021
+    - name: websocket-https
+      protocol: TCP
+      port: 8099
+    - name: websocket-http
+      protocol: TCP
+      port: 9099
 {{- end }}

--- a/all-in-one/templates/am/wso2am-service.yaml
+++ b/all-in-one/templates/am/wso2am-service.yaml
@@ -44,3 +44,9 @@ spec:
     - name: websub-https
       protocol: TCP
       port: 8021
+    - name: websocket-https
+      protocol: TCP
+      port: 8099
+    - name: websocket-http
+      protocol: TCP
+      port: 9099


### PR DESCRIPTION
Partially fixes https://github.com/wso2/api-manager/issues/4478

This pull request adds new service ports for WebSocket support to the WSO2 API Manager service definitions in the deployment templates. These changes enable the services to handle WebSocket traffic over both HTTP and HTTPS protocols.

Network/service configuration updates:

* Added `websocket-https` (TCP/8099) and `websocket-http` (TCP/9099) ports to the `wso2am-service.yaml` for the main instance, as well as for `instance-1` and `instance-2` service templates. [[1]](diffhunk://#diff-7cf87ac4c606e8e238297325d4fdcbeeed1c76ec2166789d6705a3431ee6958dR47-R52) [[2]](diffhunk://#diff-e2e042193a491f11f163c22c54b22ef97dac7de9fae358ab54b5823c0446ef16R48-R53) [[3]](diffhunk://#diff-2559eafd30b6f87712486864afe924cac79c6e1bd8a376621752603b113ff742R49-R54)