### PR TITLE
Update mtls-fix for Openshift

### DIFF
--- a/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
@@ -354,3 +354,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "am-all-in-one.fullname" . }}-am-solr-indexed-data-volume-claim
         {{ end }}
+        {{- if .Values.kubernetes.openshift.enabled }}
+        - name: wso2am-security-dir
+          emptyDir: {}
+        {{- end }}

--- a/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
@@ -277,6 +277,10 @@ spec:
             - name: wso2am-solr
               mountPath: /home/wso2carbon/solr/indexed-data
             {{ end }}
+            {{- if .Values.kubernetes.openshift.enabled }}
+            - name: wso2am-security-dir
+              mountPath: /home/wso2carbon/tmp-security
+            {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}

--- a/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
@@ -284,6 +284,10 @@ spec:
             - name: wso2am-solr
               mountPath: /home/wso2carbon/solr/indexed-data
             {{ end }}
+            {{- if .Values.kubernetes.openshift.enabled }}
+            - name: wso2am-security-dir
+              mountPath: /home/wso2carbon/tmp-security
+            {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}

--- a/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
@@ -361,4 +361,8 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "am-all-in-one.fullname" . }}-am-solr-indexed-data-volume-claim
         {{ end }}
+        {{- if .Values.kubernetes.openshift.enabled }}
+        - name: wso2am-security-dir
+          emptyDir: {}
+        {{- end }}
 {{- end }}

--- a/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
+++ b/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
@@ -52,15 +52,16 @@ data:
     {{- end }}
     {{- end }}
 
-    # For permission configuration on OpenShift.
     {{- if .Values.kubernetes.openshift.enabled }}
-    SECURITY_DIR="${WSO2_SERVER_HOME}/repository/resources/security"
-
-    if [ -d "${SECURITY_DIR}" ]; then
-    echo "Recreating ${SECURITY_DIR} in writable layer to allow runtime modifications..."
-    TMP_DIR="${SECURITY_DIR}_tmp_copyup"
-    cp -a "${SECURITY_DIR}/." "${TMP_DIR}" && rm -rf "${SECURITY_DIR}" && mv "${TMP_DIR}" "${SECURITY_DIR}"
-    chgrp -R 0 "${SECURITY_DIR}" && chmod -R g+rwX "${SECURITY_DIR}" || true
+    # For permission configuration on OpenShift.
+    echo "Openshift deployment detected."
+    # Copy security dir to writable emptyDir and symlink
+    SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
+    CONFIG_SECURITY="/home/wso2carbon/tmp-security"
+    
+    if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
+      rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
 

--- a/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
+++ b/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
@@ -60,6 +60,8 @@ data:
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     
     if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      # Clean up before copying
+      find "${CONFIG_SECURITY}" -mindepth 1 -delete 2>/dev/null || rm -rf "${CONFIG_SECURITY:?}"/* "${CONFIG_SECURITY:?}"/.[!.]* 2>/dev/null
       cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi

--- a/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
+++ b/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
@@ -55,7 +55,7 @@ data:
     {{- if .Values.kubernetes.openshift.enabled }}
     # For permission configuration on OpenShift.
     echo "Openshift deployment detected."
-    # Copy security dir to writable emptyDir and symlink
+    # Copy security dir to writable emptyDir and restore
     SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -277,6 +277,10 @@ spec:
         - name: wso2am-control-plane-solr
           mountPath: /home/wso2carbon/solr/indexed-data
         {{ end }}
+        {{- if .Values.kubernetes.openshift.enabled }}
+        - name: wso2am-security-dir
+          mountPath: /home/wso2carbon/tmp-security
+        {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}
@@ -349,3 +353,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ template "apim-helm-cp.fullname" . }}-solr-indexed-data-1
       {{ end }}
+      {{- if .Values.kubernetes.openshift.enabled }}
+      - name: wso2am-security-dir
+        emptyDir: {}
+      {{- end }}

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -354,4 +354,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ template "apim-helm-cp.fullname" . }}-solr-indexed-data-2
       {{ end }}
+      {{- if .Values.kubernetes.openshift.enabled }}
+      - name: wso2am-security-dir
+        emptyDir: {}
+      {{- end }}
 {{- end }}

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -278,6 +278,10 @@ spec:
         - name: wso2am-control-plane-solr
           mountPath: /home/wso2carbon/solr/indexed-data
         {{ end }}
+        {{- if .Values.kubernetes.openshift.enabled }}
+        - name: wso2am-security-dir
+          mountPath: /home/wso2carbon/tmp-security
+        {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}

--- a/distributed/control-plane/templates/control-plane/wso2am-cp-conf-entrypoint.yaml
+++ b/distributed/control-plane/templates/control-plane/wso2am-cp-conf-entrypoint.yaml
@@ -59,15 +59,16 @@ data:
     {{- end }}
     {{- end }}
 
-    # For permission configuration on OpenShift.
     {{- if .Values.kubernetes.openshift.enabled }}
-    SECURITY_DIR="${WSO2_SERVER_HOME}/repository/resources/security"
-
-    if [ -d "${SECURITY_DIR}" ]; then
-    echo "Recreating ${SECURITY_DIR} in writable layer to allow runtime modifications..."
-    TMP_DIR="${SECURITY_DIR}_tmp_copyup"
-    cp -a "${SECURITY_DIR}/." "${TMP_DIR}" && rm -rf "${SECURITY_DIR}" && mv "${TMP_DIR}" "${SECURITY_DIR}"
-    chgrp -R 0 "${SECURITY_DIR}" && chmod -R g+rwX "${SECURITY_DIR}" || true
+    # For permission configuration on OpenShift.
+    echo "Openshift deployment detected."
+    # Copy security dir to writable emptyDir and symlink
+    SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
+    CONFIG_SECURITY="/home/wso2carbon/tmp-security"
+    
+    if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
+      rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
 

--- a/distributed/control-plane/templates/control-plane/wso2am-cp-conf-entrypoint.yaml
+++ b/distributed/control-plane/templates/control-plane/wso2am-cp-conf-entrypoint.yaml
@@ -67,6 +67,8 @@ data:
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     
     if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      # Clean up before copying
+      find "${CONFIG_SECURITY}" -mindepth 1 -delete 2>/dev/null || rm -rf "${CONFIG_SECURITY:?}"/* "${CONFIG_SECURITY:?}"/.[!.]* 2>/dev/null
       cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi

--- a/distributed/control-plane/templates/control-plane/wso2am-cp-conf-entrypoint.yaml
+++ b/distributed/control-plane/templates/control-plane/wso2am-cp-conf-entrypoint.yaml
@@ -62,7 +62,7 @@ data:
     {{- if .Values.kubernetes.openshift.enabled }}
     # For permission configuration on OpenShift.
     echo "Openshift deployment detected."
-    # Copy security dir to writable emptyDir and symlink
+    # Copy security dir to writable emptyDir and restore
     SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     

--- a/distributed/gateway/templates/gateway/wso2am-gateway-conf-entrypoint.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-conf-entrypoint.yaml
@@ -48,7 +48,7 @@ data:
     {{- if .Values.kubernetes.openshift.enabled }}
     # For permission configuration on OpenShift.
     echo "Openshift deployment detected."
-    # Copy security dir to writable emptyDir and symlink
+    # Copy security dir to writable emptyDir and restore
     SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     

--- a/distributed/gateway/templates/gateway/wso2am-gateway-conf-entrypoint.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-conf-entrypoint.yaml
@@ -45,15 +45,16 @@ data:
     {{- end }}
     {{- end }}
   
-    # For permission configuration on OpenShift.
     {{- if .Values.kubernetes.openshift.enabled }}
-    SECURITY_DIR="${WSO2_SERVER_HOME}/repository/resources/security"
-
-    if [ -d "${SECURITY_DIR}" ]; then
-    echo "Recreating ${SECURITY_DIR} in writable layer to allow runtime modifications..."
-    TMP_DIR="${SECURITY_DIR}_tmp_copyup"
-    cp -a "${SECURITY_DIR}/." "${TMP_DIR}" && rm -rf "${SECURITY_DIR}" && mv "${TMP_DIR}" "${SECURITY_DIR}"
-    chgrp -R 0 "${SECURITY_DIR}" && chmod -R g+rwX "${SECURITY_DIR}" || true
+    # For permission configuration on OpenShift.
+    echo "Openshift deployment detected."
+    # Copy security dir to writable emptyDir and symlink
+    SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
+    CONFIG_SECURITY="/home/wso2carbon/tmp-security"
+    
+    if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
+      rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
 

--- a/distributed/gateway/templates/gateway/wso2am-gateway-conf-entrypoint.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-conf-entrypoint.yaml
@@ -53,6 +53,8 @@ data:
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     
     if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      # Clean up before copying
+      find "${CONFIG_SECURITY}" -mindepth 1 -delete 2>/dev/null || rm -rf "${CONFIG_SECURITY:?}"/* "${CONFIG_SECURITY:?}"/.[!.]* 2>/dev/null
       cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -266,6 +266,10 @@ spec:
           mountPath: /home/wso2carbon/wso2-config-volume/repository/resources/security/{{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
           subPath: {{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
         {{- end }}
+        {{- if .Values.kubernetes.openshift.enabled }}
+        - name: wso2am-security-dir
+          mountPath: /home/wso2carbon/tmp-security
+        {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}
@@ -314,3 +318,7 @@ spec:
       - name: wso2am-gateway-keystores
         secret:
           secretName: {{ .Values.wso2.apim.configurations.security.jksSecretName }}
+      {{- if .Values.kubernetes.openshift.enabled }}
+      - name: wso2am-security-dir
+        emptyDir: {}
+      {{- end }}

--- a/distributed/key-manager/templates/key-manager/wso2am-km-conf-entrypoint.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-conf-entrypoint.yaml
@@ -52,15 +52,16 @@ data:
     {{- end }}
     {{- end }}
 
-    # For permission configuration on OpenShift.
     {{- if .Values.kubernetes.openshift.enabled }}
-    SECURITY_DIR="${WSO2_SERVER_HOME}/repository/resources/security"
-
-    if [ -d "${SECURITY_DIR}" ]; then
-    echo "Recreating ${SECURITY_DIR} in writable layer to allow runtime modifications..."
-    TMP_DIR="${SECURITY_DIR}_tmp_copyup"
-    cp -a "${SECURITY_DIR}/." "${TMP_DIR}" && rm -rf "${SECURITY_DIR}" && mv "${TMP_DIR}" "${SECURITY_DIR}"
-    chgrp -R 0 "${SECURITY_DIR}" && chmod -R g+rwX "${SECURITY_DIR}" || true
+    # For permission configuration on OpenShift.
+    echo "Openshift deployment detected."
+    # Copy security dir to writable emptyDir and symlink
+    SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
+    CONFIG_SECURITY="/home/wso2carbon/tmp-security"
+    
+    if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
+      rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
 

--- a/distributed/key-manager/templates/key-manager/wso2am-km-conf-entrypoint.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-conf-entrypoint.yaml
@@ -60,6 +60,8 @@ data:
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     
     if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      # Clean up before copying
+      find "${CONFIG_SECURITY}" -mindepth 1 -delete 2>/dev/null || rm -rf "${CONFIG_SECURITY:?}"/* "${CONFIG_SECURITY:?}"/.[!.]* 2>/dev/null
       cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi

--- a/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
@@ -248,6 +248,10 @@ spec:
           mountPath: /home/wso2carbon/wso2-config-volume/repository/resources/security/{{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
           subPath: {{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
         {{- end }}
+        {{- if .Values.kubernetes.openshift.enabled }}
+        - name: wso2am-security-dir
+          mountPath: /home/wso2carbon/tmp-security
+        {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}
@@ -296,3 +300,7 @@ spec:
       - name: wso2am-km-keystores
         secret:
           secretName: {{ .Values.wso2.apim.configurations.security.jksSecretName }}
+      {{- if .Values.kubernetes.openshift.enabled }}
+      - name: wso2am-security-dir
+        emptyDir: {}
+      {{- end }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -313,3 +313,7 @@ spec:
       - name: wso2am-traffic-manager-keystores
         secret:
           secretName: {{ .Values.wso2.apim.configurations.security.jksSecretName }}
+      {{- if .Values.kubernetes.openshift.enabled }}
+      - name: wso2am-security-dir
+        emptyDir: {}
+      {{- end }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -261,6 +261,10 @@ spec:
           mountPath: /home/wso2carbon/wso2-config-volume/repository/resources/security/{{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
           subPath: {{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
         {{- end }}
+        {{- if .Values.kubernetes.openshift.enabled }}
+        - name: wso2am-security-dir
+          mountPath: /home/wso2carbon/tmp-security
+        {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -262,6 +262,10 @@ spec:
           mountPath: /home/wso2carbon/wso2-config-volume/repository/resources/security/{{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
           subPath: {{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
         {{- end }}
+        {{- if .Values.kubernetes.openshift.enabled }}
+        - name: wso2am-security-dir
+          mountPath: /home/wso2carbon/tmp-security
+        {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -314,4 +314,8 @@ spec:
       - name: wso2am-traffic-manager-keystores
         secret:
           secretName: {{ .Values.wso2.apim.configurations.security.jksSecretName }}
+      {{- if .Values.kubernetes.openshift.enabled }}
+      - name: wso2am-security-dir
+        emptyDir: {}
+      {{- end }}
 {{- end }}

--- a/distributed/traffic-manager/templates/traffic-manager/wso2am-tm-conf-entrypoint.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/wso2am-tm-conf-entrypoint.yaml
@@ -48,7 +48,7 @@ data:
     {{- if .Values.kubernetes.openshift.enabled }}
     # For permission configuration on OpenShift.
     echo "Openshift deployment detected."
-    # Copy security dir to writable emptyDir and symlink
+    # Copy security dir to writable emptyDir and restore
     SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     

--- a/distributed/traffic-manager/templates/traffic-manager/wso2am-tm-conf-entrypoint.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/wso2am-tm-conf-entrypoint.yaml
@@ -45,15 +45,16 @@ data:
     {{- end }}
     {{- end }}
   
-    # For permission configuration on OpenShift.
     {{- if .Values.kubernetes.openshift.enabled }}
-    SECURITY_DIR="${WSO2_SERVER_HOME}/repository/resources/security"
-
-    if [ -d "${SECURITY_DIR}" ]; then
-    echo "Recreating ${SECURITY_DIR} in writable layer to allow runtime modifications..."
-    TMP_DIR="${SECURITY_DIR}_tmp_copyup"
-    cp -a "${SECURITY_DIR}/." "${TMP_DIR}" && rm -rf "${SECURITY_DIR}" && mv "${TMP_DIR}" "${SECURITY_DIR}"
-    chgrp -R 0 "${SECURITY_DIR}" && chmod -R g+rwX "${SECURITY_DIR}" || true
+    # For permission configuration on OpenShift.
+    echo "Openshift deployment detected."
+    # Copy security dir to writable emptyDir and symlink
+    SRC_SECURITY="${WSO2_SERVER_HOME}/repository/resources/security"
+    CONFIG_SECURITY="/home/wso2carbon/tmp-security"
+    
+    if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
+      rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
 

--- a/distributed/traffic-manager/templates/traffic-manager/wso2am-tm-conf-entrypoint.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/wso2am-tm-conf-entrypoint.yaml
@@ -53,6 +53,8 @@ data:
     CONFIG_SECURITY="/home/wso2carbon/tmp-security"
     
     if [ -d "${SRC_SECURITY}" ] && [ -d "${CONFIG_SECURITY}" ] && [ ! -L "${SRC_SECURITY}" ]; then
+      # Clean up before copying
+      find "${CONFIG_SECURITY}" -mindepth 1 -delete 2>/dev/null || rm -rf "${CONFIG_SECURITY:?}"/* "${CONFIG_SECURITY:?}"/.[!.]* 2>/dev/null
       cp -dR "${SRC_SECURITY}/." "${CONFIG_SECURITY}/" && \
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi


### PR DESCRIPTION
## Purpose
> This PR adds the missing changes required for properly handling the file permissions required during the listener profile updation in mTLS 

- Related fix: https://github.com/wso2/helm-apim/pull/125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added OpenShift-specific security directory mounts across deployments to improve isolation and runtime behavior.
  * Replaced in-place permission tweaks with a guarded copy-and-restore flow for more reliable and safer security-directory updates during OpenShift deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->