### PR TITLE
[APIM 4.2.0] Fix OutboundAuth Header Config

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -153,9 +153,9 @@ A Helm chart for the deployment of WSO2 API Manager Single Node.
 | wso2.apim.configurations.notification.signature | string | `nil` |  |
 | wso2.apim.configurations.notification.username | string | `nil` |  |
 | wso2.apim.configurations.oauth_config.authHeader | string | `"Authorization"` | OAuth authorization header name |
+| wso2.apim.configurations.oauth_config.enableOutboundAuthHeader | bool | `false` | Preserves auth header in outgoing requests |
 | wso2.apim.configurations.oauth_config.enableTokenEncryption | bool | `false` | Enable token encryption |
 | wso2.apim.configurations.oauth_config.enableTokenHashing | bool | `false` | Enable token hashing |
-| wso2.apim.configurations.oauth_config.removeOutboundAuthHeader | bool | `true` | Remove auth header from outgoing requests |
 | wso2.apim.configurations.oauth_config.revokeEndpoint | string | `""` | OAuth revoke endpoint |
 | wso2.apim.configurations.publisher.supportedDocumentTypes | string | `""` | Supported document types in Publisher.  This should be used only if there are additional document types to be supported. |
 | wso2.apim.configurations.security.jksSecretName | string | `""` | Kubernetes secret containing the keystores and truststore |

--- a/all-in-one/confs/deployment.toml
+++ b/all-in-one/confs/deployment.toml
@@ -214,7 +214,7 @@ claims_extractor_impl = {{ .Values.wso2.apim.configurations.jwt.claimsExtractorI
 {{- end }}
 
 [apim.oauth_config]
-remove_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.removeOutboundAuthHeader }}
+enable_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.enableOutboundAuthHeader }}
 auth_header = {{ .Values.wso2.apim.configurations.oauth_config.authHeader | quote }}
 revoke_endpoint = {{ .Values.wso2.apim.configurations.oauth_config.revokeEndpoint | quote }}
 enable_token_encryption = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenEncryption }}

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -376,8 +376,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove auth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- OAuth revoke endpoint

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -84,9 +84,9 @@ A Helm chart for the deployment of WSO2 API Management Gateway profile
 | wso2.apim.configurations.km.servicePort | int | `9443` | Key Manager service port |
 | wso2.apim.configurations.km.serviceUrl | string | `"wso2am-cp-service"` | Key manager service name if default Resident KM is used |
 | wso2.apim.configurations.oauth_config.authHeader | string | `"Authorization"` | OAuth authorization header name |
+| wso2.apim.configurations.oauth_config.enableOutboundAuthHeader | bool | `false` | Preserves auth header in outgoing requests |
 | wso2.apim.configurations.oauth_config.enableTokenEncryption | bool | `false` | Enable token encryption |
 | wso2.apim.configurations.oauth_config.enableTokenHashing | bool | `false` | Enable token hashing |
-| wso2.apim.configurations.oauth_config.removeOutboundAuthHeader | bool | `true` | Remove oauth header from outgoing requests |
 | wso2.apim.configurations.openTelemetry.enabled | bool | `false` | Open Telemetry enabled |
 | wso2.apim.configurations.openTelemetry.hostname | string | `""` | Remote tracer hostname |
 | wso2.apim.configurations.openTelemetry.name | string | `""` | Remote tracer name. e.g. jaeger, zipkin, OTLP |

--- a/distributed/gateway/confs/deployment.toml
+++ b/distributed/gateway/confs/deployment.toml
@@ -179,7 +179,7 @@ enable = {{ .Values.wso2.apim.configurations.cache.jwt_claim.enabled }}
 expiry_time = {{ .Values.wso2.apim.configurations.cache.jwt_claim.expiryTime }}
 
 [apim.oauth_config]
-remove_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.removeOutboundAuthHeader }}
+enable_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.enableOutboundAuthHeader }}
 auth_header = {{ .Values.wso2.apim.configurations.oauth_config.authHeader | quote }}
 enable_token_encryption = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenEncryption }}
 enable_token_hashing = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenHashing }}

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -295,8 +295,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove oauth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- Enable token encryption


### PR DESCRIPTION
Related to https://github.com/wso2-enterprise/wso2-apim-internal/issues/16087

This pull request updates the configuration for handling OAuth authorization headers in both the all-in-one and distributed gateway Helm charts for WSO2 API Manager. The main change is replacing the `removeOutboundAuthHeader` option with a new `enableOutboundAuthHeader` option, which reverses the logic and clarifies the configuration's intent. The update is reflected across documentation, values files, and deployment templates.
