### PR TITLE
[APIM 4.5.0] Fix OutboundAuth Header Config

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -171,7 +171,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.apim.configurations.oauth_config.enableTokenEncryption | bool | `false` | Enable token encryption |
 | wso2.apim.configurations.oauth_config.enableTokenHashing | bool | `false` | Enable token hashing |
 | wso2.apim.configurations.oauth_config.oauth2JWKSUrl | string | `""` |  |
-| wso2.apim.configurations.oauth_config.removeOutboundAuthHeader | bool | `true` | Remove auth header from outgoing requests |
+| wso2.apim.configurations.oauth_config.enableOutboundAuthHeader | bool | `false` | Preserves auth header in outgoing requests |
 | wso2.apim.configurations.oauth_config.revokeEndpoint | string | `""` | OAuth revoke endpoint |
 | wso2.apim.configurations.openTelemetry.enabled | bool | `false` | Open Telemetry enabled |
 | wso2.apim.configurations.openTelemetry.hostname | string | `""` | Remote tracer hostname |

--- a/all-in-one/confs/instance-1/deployment.toml
+++ b/all-in-one/confs/instance-1/deployment.toml
@@ -263,7 +263,7 @@ claims_extractor_impl = {{ .Values.wso2.apim.configurations.jwt.claimsExtractorI
 {{- end }}
 
 [apim.oauth_config]
-remove_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.removeOutboundAuthHeader }}
+enable_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.enableOutboundAuthHeader }}
 auth_header = {{ .Values.wso2.apim.configurations.oauth_config.authHeader | quote }}
 revoke_endpoint = {{ .Values.wso2.apim.configurations.oauth_config.revokeEndpoint | quote }}
 enable_token_encryption = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenEncryption }}

--- a/all-in-one/confs/instance-2/deployment.toml
+++ b/all-in-one/confs/instance-2/deployment.toml
@@ -263,7 +263,7 @@ claims_extractor_impl = {{ .Values.wso2.apim.configurations.jwt.claimsExtractorI
 {{- end }}
 
 [apim.oauth_config]
-remove_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.removeOutboundAuthHeader }}
+enable_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.enableOutboundAuthHeader }}
 auth_header = {{ .Values.wso2.apim.configurations.oauth_config.authHeader | quote }}
 revoke_endpoint = {{ .Values.wso2.apim.configurations.oauth_config.revokeEndpoint | quote }}
 enable_token_encryption = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenEncryption }}

--- a/all-in-one/default_openshift_values.yaml
+++ b/all-in-one/default_openshift_values.yaml
@@ -419,8 +419,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove auth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- OAuth revoke endpoint

--- a/all-in-one/default_values.yaml
+++ b/all-in-one/default_values.yaml
@@ -419,8 +419,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove auth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- OAuth revoke endpoint

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -437,8 +437,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove auth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- OAuth revoke endpoint

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -101,7 +101,7 @@ A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 | wso2.apim.configurations.oauth_config.authHeader | string | `"Authorization"` | OAuth authorization header name |
 | wso2.apim.configurations.oauth_config.enableTokenEncryption | bool | `false` | Enable token encryption |
 | wso2.apim.configurations.oauth_config.enableTokenHashing | bool | `false` | Enable token hashing |
-| wso2.apim.configurations.oauth_config.removeOutboundAuthHeader | bool | `true` | Remove oauth header from outgoing requests |
+| wso2.apim.configurations.oauth_config.enableOutboundAuthHeader | bool | `false` | Preserves auth header in outgoing requests |
 | wso2.apim.configurations.openTelemetry.enabled | bool | `false` | Open Telemetry enabled |
 | wso2.apim.configurations.openTelemetry.hostname | string | `""` | Remote tracer hostname |
 | wso2.apim.configurations.openTelemetry.name | string | `""` | Remote tracer name. e.g. jaeger, zipkin, OTLP |

--- a/distributed/gateway/confs/deployment.toml
+++ b/distributed/gateway/confs/deployment.toml
@@ -205,7 +205,7 @@ enable = {{ .Values.wso2.apim.configurations.cache.jwt_claim.enabled }}
 expiry_time = {{ .Values.wso2.apim.configurations.cache.jwt_claim.expiryTime }}
 
 [apim.oauth_config]
-remove_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.removeOutboundAuthHeader }}
+enable_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.enableOutboundAuthHeader }}
 auth_header = {{ .Values.wso2.apim.configurations.oauth_config.authHeader | quote }}
 enable_token_encryption = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenEncryption }}
 enable_token_hashing = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenHashing }}

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -361,8 +361,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove oauth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- Enable token encryption

--- a/docs/am-pattern-0-all-in-one/default_values.yaml
+++ b/docs/am-pattern-0-all-in-one/default_values.yaml
@@ -402,8 +402,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove auth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- OAuth revoke endpoint

--- a/docs/am-pattern-1-all-in-one-HA/default_values.yaml
+++ b/docs/am-pattern-1-all-in-one-HA/default_values.yaml
@@ -416,8 +416,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove auth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- OAuth revoke endpoint

--- a/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+++ b/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
@@ -317,8 +317,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove oauth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- Enable token encryption

--- a/docs/am-pattern-2-all-in-one_GW/default_values.yaml
+++ b/docs/am-pattern-2-all-in-one_GW/default_values.yaml
@@ -403,8 +403,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove auth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- OAuth revoke endpoint

--- a/docs/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+++ b/docs/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
@@ -319,8 +319,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove oauth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- Enable token encryption

--- a/docs/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+++ b/docs/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
@@ -319,8 +319,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove oauth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- Enable token encryption

--- a/docs/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
+++ b/docs/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
@@ -317,8 +317,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove oauth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- Enable token encryption

--- a/docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml
+++ b/docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml
@@ -410,8 +410,8 @@ wso2:
 
       # APIM OAuth configurations
       oauth_config:
-        # -- Remove auth header from outgoing requests
-        removeOutboundAuthHeader: true
+        # -- Preserves auth header in outgoing requests
+        enableOutboundAuthHeader: false
         # -- OAuth authorization header name
         authHeader: "Authorization"
         # -- OAuth revoke endpoint


### PR DESCRIPTION
Related to wso2-enterprise/wso2-apim-internal#16134

This pull request updates the configuration for handling OAuth authorization headers in both the all-in-one and distributed gateway Helm charts for WSO2 API Manager. The main change is replacing the removeOutboundAuthHeader option with a new enableOutboundAuthHeader option, which reverses the logic and clarifies the configuration's intent. The update is reflected across documentation, values files, and deployment templates.