### PR TITLE
feat: add imagePullSecret reference configuration option

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -365,7 +365,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.highAvailability | bool | `false` |  |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,name:"","password":"","username":""}` | Container registry credentials. Specify image pull secrets or a reference to secret for private registries |
 | wso2.deployment.image.registry | string | `""` | Registry containing the image |
 | wso2.deployment.image.repository | string | `""` | Repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/all-in-one/default_values.yaml
+++ b/all-in-one/default_values.yaml
@@ -743,6 +743,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Registry containing the image

--- a/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
@@ -63,7 +63,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+        {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+        {{- else }}
       - name: {{ template "am-all-in-one.fullname" . }}-docker-registry-auth
+        {{- end }}
       {{- end }}
       containers:
         - name: wso2am

--- a/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
@@ -64,7 +64,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+        {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+        {{- else }}
       - name: {{ template "am-all-in-one.fullname" . }}-docker-registry-auth
+        {{- end }}
       {{- end }}
       containers:
         - name: wso2am

--- a/all-in-one/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/all-in-one/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -843,6 +843,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Registry containing the image

--- a/distributed/control-plane/README.md
+++ b/distributed/control-plane/README.md
@@ -234,7 +234,7 @@ A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 | wso2.deployment.highAvailability | bool | `true` | Enable high availability for traffic manager. If this is enabled, two traffic manager instances will be deployed. This is not relavant to HA in Kubernetes. Multiple replicas of the same instance will not count as HA for TM. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,name:"","password":"","username":""}` | Container registry credentials. Specify image pull secrets or a reference to secret for private registries |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -66,7 +66,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+        {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+        {{- else }}
       - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+        {{- end }}
       {{- end }}
       containers:
       - name: wso2am-control-plane

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -67,7 +67,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+        {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+        {{- else }}
       - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+        {{- end }}
       {{- end }}
       containers:
       - name: wso2am-control-plane

--- a/distributed/control-plane/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/control-plane/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -619,6 +619,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -219,7 +219,7 @@ A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 | wso2.deployment.envs | object | `{}` | Environment variables for the deployment Example:   envs:     MY_CUSTOM_VAR: "my-value"     ANOTHER_VAR: "another-value" |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,name:"","password":"","username":""}` | Container registry credentials. Specify image pull secrets or a reference to secret for private registries |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -67,7 +67,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+        {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+        {{- else }}
       - name: {{ template "apim-helm-gw.fullname" . }}-docker-registry-auth
+        {{- end }}
       {{- end }}
       containers:
       - name: wso2am-gateway

--- a/distributed/gateway/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/gateway/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -577,6 +577,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/distributed/key-manager/README.md
+++ b/distributed/key-manager/README.md
@@ -145,7 +145,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.highAvailability | bool | `false` | Enable high availability for key manager. If this is enabled, two key manager replicas will be deployed. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,name:"","password":"","username":""}` | Container registry credentials. Specify image pull secrets or a reference to secret for private registries |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
@@ -71,7 +71,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+        {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+        {{- else }}
       - name: {{ template "apim-helm-km.fullname" . }}-docker-registry-auth
+        {{- end }}
       {{- end }}
       containers:
       - name: wso2am-km

--- a/distributed/key-manager/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/key-manager/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -390,6 +390,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        namme: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -120,7 +120,7 @@ A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 | wso2.deployment.highAvailability | bool | `true` | Enable high availability for traffic manager. If this is enabled, two traffic manager instances will be deployed. This is not relavant to HA in Kubernetes. Multiple replicas of the same instance will not count as HA for TM. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,name:"","password":"","username":""}` | Container registry credentials. Specify image pull secrets or a reference to secret for private registries |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/distributed/traffic-manager/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/traffic-manager/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -69,7 +69,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+        {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+        {{- else }}
       - name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
+        {{- end }}
       {{- end }}
       containers:
       - name: wso2am-traffic-manager

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -70,7 +70,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+        {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+        {{- else }}
       - name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
+        {{- end }}
       {{- end }}
       containers:
       - name: wso2am-traffic-manager

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -347,6 +347,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname


### PR DESCRIPTION
## Purpose

Currently imagePullSecret requires a username/password in the values.yaml and does not allow to reference custom (encrypted) secrets.

## Goals

Add a `imagePullSecret.name` property which allows to reference custom secrets while keeping backwards compatability.

## Approach

Adds conditionals to either set the imagePullSecret name or use the prior assembled/generated secret.
