### PR TITLE
Add config to set ulimits

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -112,6 +112,9 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |
 | kubernetes.securityContext.seccompProfile.type | string | `"RuntimeDefault"` | Seccomp profile type(RuntimeDefault, Unconfined or Localhost) |
+| kubernetes.ulimits | object | `{"nofile":"","nproc":""}` | ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000. |
+| kubernetes.ulimits.nofile | string | `""` | Soft limit for open file descriptors (ulimit -Sn). e.g., 20000 |
+| kubernetes.ulimits.nproc | string | `""` | Soft limit for number of processes (ulimit -Su). e.g., 20000 |
 | wso2.ELKAnalytics | object | `{"enabled":false}` | ELK Analytics Parameters |
 | wso2.apim.configurations.adminPassword | string | `"admin"` | Super admin password |
 | wso2.apim.configurations.adminUsername | string | `"admin"` | Super admin username |

--- a/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
+++ b/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
@@ -64,6 +64,12 @@ data:
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
+    {{- if .Values.kubernetes.ulimits.nofile }}
+    ulimit -Sn {{ .Values.kubernetes.ulimits.nofile }}
+    {{- end }}
+    {{- if .Values.kubernetes.ulimits.nproc }}
+    ulimit -Su {{ .Values.kubernetes.ulimits.nproc }}
+    {{- end }}
 
     # start WSO2 Carbon server
     sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@" {{ .Values.wso2.apim.startupArgs }}

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -133,6 +133,13 @@ kubernetes:
   openshift:
     enabled: false
 
+  # -- ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000.
+  ulimits:
+    # -- Soft limit for open file descriptors (ulimit -Sn). e.g., 20000
+    nofile: ""
+    # -- Soft limit for number of processes (ulimit -Su). e.g., 20000
+    nproc: ""
+
   # -- Ingress class to be used for the ingress resource
   ingressClass: "nginx"
   ingress:

--- a/distributed/control-plane/README.md
+++ b/distributed/control-plane/README.md
@@ -97,6 +97,9 @@ A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |
 | kubernetes.securityContext.seccompProfile.type | string | `"RuntimeDefault"` | Seccomp profile type(RuntimeDefault, Unconfined or Localhost) |
+| kubernetes.ulimits | object | `{"nofile":"","nproc":""}` | ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000. |
+| kubernetes.ulimits.nofile | string | `""` | Soft limit for open file descriptors (ulimit -Sn). e.g., 20000 |
+| kubernetes.ulimits.nproc | string | `""` | Soft limit for number of processes (ulimit -Su). e.g., 20000 |
 | wso2.apim.configurations.adminPassword | string | `""` | Super admin password |
 | wso2.apim.configurations.adminPasswordExistingSecret | object | `{"secretKey":"","secretName":""}` | Read password from secret |
 | wso2.apim.configurations.adminUsername | string | `""` | Super admin username |

--- a/distributed/control-plane/templates/control-plane/wso2am-cp-conf-entrypoint.yaml
+++ b/distributed/control-plane/templates/control-plane/wso2am-cp-conf-entrypoint.yaml
@@ -71,6 +71,12 @@ data:
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
+    {{- if .Values.kubernetes.ulimits.nofile }}
+    ulimit -Sn {{ .Values.kubernetes.ulimits.nofile }}
+    {{- end }}
+    {{- if .Values.kubernetes.ulimits.nproc }}
+    ulimit -Su {{ .Values.kubernetes.ulimits.nproc }}
+    {{- end }}
 
     # start WSO2 Carbon server
     echo "Start WSO2 Carbon server" >&2

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -147,6 +147,13 @@ kubernetes:
   openshift:
     enabled: false
 
+  # -- ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000.
+  ulimits:
+    # -- Soft limit for open file descriptors (ulimit -Sn). e.g., 20000
+    nofile: ""
+    # -- Soft limit for number of processes (ulimit -Su). e.g., 20000
+    nproc: ""
+
   # -- Ingress class to be used for the ingress resource
   ingressClass: "nginx"
   ingress:

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -76,6 +76,9 @@ A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |
 | kubernetes.securityContext.seccompProfile.type | string | `"RuntimeDefault"` | Seccomp profile type(RuntimeDefault, Unconfined or Localhost) |
+| kubernetes.ulimits | object | `{"nofile":"","nproc":""}` | ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000. |
+| kubernetes.ulimits.nofile | string | `""` | Soft limit for open file descriptors (ulimit -Sn). e.g., 20000 |
+| kubernetes.ulimits.nproc | string | `""` | Soft limit for number of processes (ulimit -Su). e.g., 20000 |
 | wso2.ELKAnalytics | object | `{"enabled":false}` | ELK Analytics Parameters |
 | wso2.apim.configurations.adminPassword | string | `""` | Super admin password |
 | wso2.apim.configurations.adminUsername | string | `""` | Super admin username |

--- a/distributed/gateway/templates/gateway/wso2am-gateway-conf-entrypoint.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-conf-entrypoint.yaml
@@ -57,6 +57,12 @@ data:
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
+    {{- if .Values.kubernetes.ulimits.nofile }}
+    ulimit -Sn {{ .Values.kubernetes.ulimits.nofile }}
+    {{- end }}
+    {{- if .Values.kubernetes.ulimits.nproc }}
+    ulimit -Su {{ .Values.kubernetes.ulimits.nproc }}
+    {{- end }}
 
     # start WSO2 Carbon server
     echo "Start WSO2 Carbon server" >&2

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -79,6 +79,13 @@ kubernetes:
   openshift:
     enabled: false
 
+  # -- ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000.
+  ulimits:
+    # -- Soft limit for open file descriptors (ulimit -Sn). e.g., 20000
+    nofile: ""
+    # -- Soft limit for number of processes (ulimit -Su). e.g., 20000
+    nproc: ""
+
   # -- Ingress class to be used for the ingress resource
   ingressClass: "nginx"
   ingress:

--- a/distributed/key-manager/README.md
+++ b/distributed/key-manager/README.md
@@ -64,6 +64,9 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |
 | kubernetes.securityContext.seccompProfile.type | string | `"RuntimeDefault"` | Seccomp profile type(RuntimeDefault, Unconfined or Localhost) |
+| kubernetes.ulimits | object | `{"nofile":"","nproc":""}` | ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000. |
+| kubernetes.ulimits.nofile | string | `""` | Soft limit for open file descriptors (ulimit -Sn). e.g., 20000 |
+| kubernetes.ulimits.nproc | string | `""` | Soft limit for number of processes (ulimit -Su). e.g., 20000 |
 | wso2.apim.configurations.adminPassword | string | `""` | Super admin password |
 | wso2.apim.configurations.adminUsername | string | `""` | Super admin username |
 | wso2.apim.configurations.databases.apim_db | object | `{"password":"","poolParameters":{"defaultAutoCommit":true,"maxActive":100,"maxWait":60000,"minIdle":5,"testOnBorrow":true,"testWhileIdle":true,"validationInterval":30000},"url":"","username":""}` | APIM AM_DB configurations. |

--- a/distributed/key-manager/templates/key-manager/wso2am-km-conf-entrypoint.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-conf-entrypoint.yaml
@@ -64,6 +64,12 @@ data:
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
+    {{- if .Values.kubernetes.ulimits.nofile }}
+    ulimit -Sn {{ .Values.kubernetes.ulimits.nofile }}
+    {{- end }}
+    {{- if .Values.kubernetes.ulimits.nproc }}
+    ulimit -Su {{ .Values.kubernetes.ulimits.nproc }}
+    {{- end }}
 
     # start WSO2 Carbon server
     echo "Start WSO2 Carbon server" >&2

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -85,6 +85,13 @@ kubernetes:
   openshift:
     enabled: false
 
+  # -- ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000.
+  ulimits:
+    # -- Soft limit for open file descriptors (ulimit -Sn). e.g., 20000
+    nofile: ""
+    # -- Soft limit for number of processes (ulimit -Su). e.g., 20000
+    nproc: ""
+
   # -- Ingress class to be used for the ingress resource
   ingressClass: "nginx"
   ingress:

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -45,6 +45,9 @@ A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |
 | kubernetes.securityContext.seccompProfile.type | string | `"RuntimeDefault"` | Seccomp profile type(RuntimeDefault, Unconfined or Localhost) |
+| kubernetes.ulimits | object | `{"nofile":"","nproc":""}` | ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000. |
+| kubernetes.ulimits.nofile | string | `""` | Soft limit for open file descriptors (ulimit -Sn). e.g., 20000 |
+| kubernetes.ulimits.nproc | string | `""` | Soft limit for number of processes (ulimit -Su). e.g., 20000 |
 | wso2.apim.configurations.adminPassword | string | `""` | Super admin password |
 | wso2.apim.configurations.adminUsername | string | `""` | Super admin username |
 | wso2.apim.configurations.databases.apim_db | object | `{"password":"","poolParameters":{"defaultAutoCommit":true,"maxActive":100,"maxWait":60000,"minIdle":5,"testOnBorrow":true,"testWhileIdle":true,"validationInterval":30000},"url":"","username":""}` | APIM AM_DB configurations. |

--- a/distributed/traffic-manager/templates/traffic-manager/wso2am-tm-conf-entrypoint.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/wso2am-tm-conf-entrypoint.yaml
@@ -57,6 +57,12 @@ data:
       rm -rf "${SRC_SECURITY}" && cp -dR "${CONFIG_SECURITY}/." "${SRC_SECURITY}/"
     fi
     {{- end }}
+    {{- if .Values.kubernetes.ulimits.nofile }}
+    ulimit -Sn {{ .Values.kubernetes.ulimits.nofile }}
+    {{- end }}
+    {{- if .Values.kubernetes.ulimits.nproc }}
+    ulimit -Su {{ .Values.kubernetes.ulimits.nproc }}
+    {{- end }}
 
     # start WSO2 Carbon server
     echo "Start WSO2 Carbon server" >&2

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -85,6 +85,13 @@ kubernetes:
   openshift:
     enabled: false
 
+  # -- ulimit settings for the container entrypoint (leave empty to skip). For AWS Fargate, you must override the default limit of 1024 for nofile and nproc to meet the WSO2 recommendation of 20000.
+  ulimits:
+    # -- Soft limit for open file descriptors (ulimit -Sn). e.g., 20000
+    nofile: ""
+    # -- Soft limit for number of processes (ulimit -Su). e.g., 20000
+    nproc: ""
+
   securityContext:
     # -- User ID of the container
     runAsUser: 10001


### PR DESCRIPTION
## Purpose
This PR adds support for overriding ulimit settings via values.yaml. When deploying WSO2 API Manager on AWS Fargate, the default nproc and nofile limits (1024) are insufficient for the APIM pod. To ensure stability and performance, these must be overridden to meet WSO2’s recommended requirements.