### PR TITLE
Feature to allow adding sidecars through helm overrides

### DIFF
--- a/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
@@ -292,6 +292,9 @@ spec:
             - name: wso2am-security-dir
               mountPath: /home/wso2carbon/tmp-security
             {{- end }}
+        {{- with .Values.wso2.deployment.sidecar }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}

--- a/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
@@ -299,6 +299,9 @@ spec:
             - name: wso2am-security-dir
               mountPath: /home/wso2carbon/tmp-security
             {{- end }}
+        {{- with .Values.wso2.deployment.sidecar }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.wso2.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -954,3 +954,4 @@ wso2:
           # -- For persisting the indexed solr data
           solrIndexedData: 50M
 
+    sidecar: {}


### PR DESCRIPTION
## Purpose
> Current deployment model prevents adding sidecars such as filebeat without having to pull the helm chart and injecting custom deployment.yaml

## Goals
> implementation of a templated sidecar from helm overrides increases flexibility for consumers

## Approach
> The implementation is just a simple toYaml from the helm overrides

## User stories
> Summary of user stories addressed by this change>

## Release note
> Add the ability to add custom sidecars from helm overrides

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - N/A

## Security checks
 - N/A

## Samples
>  
```
sidecar:
- name: filebeat-sidecar
  command: ["/bin/bash"]
  args: ["-c", "exec /entrypoint/entrypoint.sh"]
  image: docker.elastic.co/beats/filebeat:8.19.14
  imagePullPolicy: Always
  resources: {}
  terminationMessagePath: /dev/termination-log
  terminationMessagePolicy: File
  volumeMounts:
    - mountPath: /home/wso2carbon/logs
      name: logs
```

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A