### PR TITLE
feat: add imagePullSecrets.name to reference existing registry secrets

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -373,7 +373,8 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.highAvailability | bool | `false` |  |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"name":"","password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets.name | string | `""` | Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created. |
 | wso2.deployment.image.registry | string | `""` | Registry containing the image |
 | wso2.deployment.image.repository | string | `""` | Repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/all-in-one/default_openshift_values.yaml
+++ b/all-in-one/default_openshift_values.yaml
@@ -662,6 +662,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Registry containing the image

--- a/all-in-one/default_openshift_values.yaml
+++ b/all-in-one/default_openshift_values.yaml
@@ -662,6 +662,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/all-in-one/default_values.yaml
+++ b/all-in-one/default_values.yaml
@@ -760,6 +760,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/all-in-one/default_values.yaml
+++ b/all-in-one/default_values.yaml
@@ -760,6 +760,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Registry containing the image

--- a/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
@@ -63,7 +63,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+      {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+      {{- else }}
       - name: {{ template "am-all-in-one.fullname" . }}-docker-registry-auth
+      {{- end }}
       {{- end }}
       containers:
         - name: wso2am

--- a/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
@@ -64,7 +64,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+      {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+      {{- else }}
       - name: {{ template "am-all-in-one.fullname" . }}-docker-registry-auth
+      {{- end }}
       {{- end }}
       containers:
         - name: wso2am

--- a/all-in-one/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/all-in-one/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -862,6 +862,8 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created.
+        name: ""
         username: ""
         password: ""
       # -- Registry containing the image

--- a/distributed/control-plane/README.md
+++ b/distributed/control-plane/README.md
@@ -242,7 +242,8 @@ A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 | wso2.deployment.highAvailability | bool | `true` | Enable high availability for traffic manager. If this is enabled, two traffic manager instances will be deployed. This is not relavant to HA in Kubernetes. Multiple replicas of the same instance will not count as HA for TM. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"name":"","password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets.name | string | `""` | Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created. |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -66,7 +66,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+      {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+      {{- else }}
       - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+      {{- end }}
       {{- end }}
       containers:
       - name: wso2am-control-plane

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -67,7 +67,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+      {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+      {{- else }}
       - name: {{ template "apim-helm-cp.fullname" . }}-docker-registry-auth
+      {{- end }}
       {{- end }}
       containers:
       - name: wso2am-control-plane

--- a/distributed/control-plane/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/control-plane/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -637,6 +637,8 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created.
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -216,7 +216,8 @@ A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 | wso2.deployment.envs | object | `{}` | Environment variables for the deployment Example:   envs:     MY_CUSTOM_VAR: "my-value"     ANOTHER_VAR: "another-value" |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"name":"","password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets.name | string | `""` | Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created. |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -67,7 +67,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+      {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+      {{- else }}
       - name: {{ template "apim-helm-gw.fullname" . }}-docker-registry-auth
+      {{- end }}
       {{- end }}
       containers:
       - name: wso2am-gateway

--- a/distributed/gateway/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/gateway/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -562,6 +562,8 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created.
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/distributed/key-manager/README.md
+++ b/distributed/key-manager/README.md
@@ -152,7 +152,8 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.highAvailability | bool | `false` | Enable high availability for key manager. If this is enabled, two key manager replicas will be deployed. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"name":"","password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets.name | string | `""` | Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created. |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
@@ -71,7 +71,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+      {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+      {{- else }}
       - name: {{ template "apim-helm-km.fullname" . }}-docker-registry-auth
+      {{- end }}
       {{- end }}
       containers:
       - name: wso2am-km

--- a/distributed/key-manager/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/key-manager/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -405,6 +405,8 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created.
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -111,7 +111,8 @@ A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 | wso2.deployment.highAvailability | bool | `true` | Enable high availability for traffic manager. If this is enabled, two traffic manager instances will be deployed. This is not relavant to HA in Kubernetes. Multiple replicas of the same instance will not count as HA for TM. |
 | wso2.deployment.image.digest | string | `""` | Docker image digest |
 | wso2.deployment.image.imagePullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets | object | `{"enabled":false,"name":"","password":"","username":""}` | Container registry credentials. Specify image pull secrets for private registries |
+| wso2.deployment.image.imagePullSecrets.name | string | `""` | Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created. |
 | wso2.deployment.image.registry | string | `""` | Container registry hostname |
 | wso2.deployment.image.repository | string | `""` | Azure ACR repository name consisting the image |
 | wso2.deployment.image.tag | string | `""` | Docker image tag |

--- a/distributed/traffic-manager/templates/secrets/wso2am-secret-docker-registry.yaml
+++ b/distributed/traffic-manager/templates/secrets/wso2am-secret-docker-registry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
+{{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled (not .Values.wso2.deployment.image.imagePullSecrets.name) }}
 # -------------------------------------------------------------------------------------
 #
 # Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -69,7 +69,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+      {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+      {{- else }}
       - name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
+      {{- end }}
       {{- end }}
       containers:
       - name: wso2am-traffic-manager

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -70,7 +70,11 @@ spec:
           {{- end }}
       {{- if and .Values.wso2.deployment.image.imagePullSecrets.enabled }}
       imagePullSecrets:
+      {{- if .Values.wso2.deployment.image.imagePullSecrets.name }}
+      - name: {{ .Values.wso2.deployment.image.imagePullSecrets.name }}
+      {{- else }}
       - name: {{ template "apim-helm-tm.fullname" . }}-docker-registry-auth
+      {{- end }}
       {{- end }}
       containers:
       - name: wso2am-traffic-manager

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -313,6 +313,8 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created.
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-0-all-in-one/default_values.yaml
+++ b/resources/am-pattern-0-all-in-one/default_values.yaml
@@ -683,6 +683,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-0-all-in-one/default_values.yaml
+++ b/resources/am-pattern-0-all-in-one/default_values.yaml
@@ -683,6 +683,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Registry containing the image

--- a/resources/am-pattern-1-all-in-one-HA/default_values.yaml
+++ b/resources/am-pattern-1-all-in-one-HA/default_values.yaml
@@ -702,6 +702,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-1-all-in-one-HA/default_values.yaml
+++ b/resources/am-pattern-1-all-in-one-HA/default_values.yaml
@@ -702,6 +702,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+++ b/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
@@ -443,6 +443,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+++ b/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
@@ -443,6 +443,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-2-all-in-one_GW/default_values.yaml
+++ b/resources/am-pattern-2-all-in-one_GW/default_values.yaml
@@ -676,6 +676,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Registry containing the image

--- a/resources/am-pattern-2-all-in-one_GW/default_values.yaml
+++ b/resources/am-pattern-2-all-in-one_GW/default_values.yaml
@@ -676,6 +676,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
@@ -495,6 +495,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
@@ -495,6 +495,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
@@ -445,6 +445,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
@@ -445,6 +445,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
@@ -241,6 +241,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
@@ -241,6 +241,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
@@ -495,6 +495,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
@@ -495,6 +495,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
@@ -445,6 +445,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
@@ -445,6 +445,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
@@ -327,6 +327,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
@@ -327,6 +327,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
@@ -241,6 +241,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
@@ -241,6 +241,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
@@ -443,6 +443,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
@@ -443,6 +443,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
@@ -327,6 +327,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Container registry hostname

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
@@ -327,6 +327,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_values.yaml
@@ -684,6 +684,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        name: ""
         username: ""
         password: ""
       # -- Registry containing the image

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_values.yaml
@@ -684,6 +684,7 @@ wso2:
       # Specify image pull secrets for private registries
       imagePullSecrets:
         enabled: false
+        # -- Name of an existing image pull secret in the namespace. If set, this secret is used directly and no new secret is created from username/password credentials.
         name: ""
         username: ""
         password: ""


### PR DESCRIPTION
## Summary

- Adds optional `imagePullSecrets.name` field to all chart `values.yaml` files (control-plane, traffic-manager, gateway, key-manager, all-in-one) and their `default_values.yaml` counterparts
- When `imagePullSecrets.name` is set, the chart uses the named pre-existing secret directly instead of creating a new `kubernetes.io/dockerconfigjson` Secret from credentials
- When `imagePullSecrets.name` is empty (default), existing credential-based behaviour is preserved — fully backward compatible

## Motivation

Customers deploying APIM Helm charts in environments with centrally-managed image pull secrets (e.g. via Sealed Secrets, Vault, or corporate CI/CD pipelines) currently have no way to reference an existing secret by name. They must either supply raw credentials in `values.yaml` or modify chart source directly.

This change adds the missing `name` field alongside the existing `username`/`password` fields, making both workflows available without breaking any existing deployment.

Note: a similar change is proposed in #202 for `main`; this PR backports the equivalent fix to the `4.7.x` branch.

## Files changed

- `distributed/*/values.yaml` — added `imagePullSecrets.name: ""`
- `distributed/*/templates/secrets/wso2am-secret-docker-registry.yaml` — skip secret creation when `name` is set
- `distributed/*/templates/*/deployment.yaml` — reference named secret when `name` is set
- `all-in-one/values.yaml`, `all-in-one/default_values.yaml`, `all-in-one/templates/...` — same changes
- `resources/am-pattern-*/default_*_values.yaml` (16 files) — added `imagePullSecrets.name: ""`

## Test plan

- [ ] `helm lint` passes on all 5 charts
- [ ] `helm template` with `imagePullSecrets.enabled=true,name=my-secret` shows `imagePullSecrets: [{name: my-secret}]` and no registry auth Secret rendered
- [ ] `helm template` with `imagePullSecrets.enabled=true,username=u,password=p` still renders the registry auth Secret and references it (backward compat)
- [ ] `helm template` with `imagePullSecrets.enabled=false` renders no `imagePullSecrets` field (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)