### PR TITLE
feat: add runAsGroup to distributed chart security contexts

### DIFF
--- a/distributed/control-plane/README.md
+++ b/distributed/control-plane/README.md
@@ -110,6 +110,7 @@ A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 | kubernetes.route.tls.insecureEdgeTerminationPolicy | string | `"None"` | Insecure Edge Termination Policy |
 | kubernetes.route.tls.key | string | `""` | TLS private key for edge/reencrypt termination |
 | kubernetes.route.tls.termination | string | `"passthrough"` | TLS termination type (passthrough, edge, reencrypt) |
+| kubernetes.securityContext.runAsGroup | int | `10001` | Group ID of the container |
 | kubernetes.securityContext.runAsUser | int | `10001` | User ID of the container |
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -208,6 +208,7 @@ spec:
             cpu: {{ .Values.wso2.deployment.resources.limits.cpu }}
         securityContext:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.kubernetes.securityContext.runAsGroup }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           {{- if .Values.kubernetes.securityContext.seLinux.enabled }}

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -209,6 +209,7 @@ spec:
             cpu: {{ .Values.wso2.deployment.resources.limits.cpu }}
         securityContext:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.kubernetes.securityContext.runAsGroup }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           {{- if .Values.kubernetes.securityContext.seLinux.enabled }}

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -249,6 +249,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
     # -- SELinux context for the container
     seLinux:
       enabled: false

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -95,6 +95,7 @@ A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 | kubernetes.route.websub.annotations | string | `nil` | Route annotations for Websub |
 | kubernetes.route.websub.enabled | bool | `false` | Enable route for Websub |
 | kubernetes.route.websub.hostname | string | `"websub.wso2.com"` | Route hostname for Websub |
+| kubernetes.securityContext.runAsGroup | int | `10001` | Group ID of the container |
 | kubernetes.securityContext.runAsUser | int | `10001` | User ID of the container |
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -210,6 +210,7 @@ spec:
             cpu: {{ .Values.wso2.deployment.resources.limits.cpu }}
         securityContext:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.kubernetes.securityContext.runAsGroup }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           {{- if .Values.kubernetes.securityContext.seLinux.enabled }}

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -217,6 +217,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
     # -- SELinux context for the container
     seLinux:
       enabled: false

--- a/distributed/key-manager/README.md
+++ b/distributed/key-manager/README.md
@@ -77,6 +77,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | kubernetes.route.tls.insecureEdgeTerminationPolicy | string | `"None"` | Insecure Edge Termination Policy |
 | kubernetes.route.tls.key | string | `""` | TLS private key for edge/reencrypt termination |
 | kubernetes.route.tls.termination | string | `"passthrough"` | TLS termination type (passthrough, edge, reencrypt) |
+| kubernetes.securityContext.runAsGroup | int | `10001` | Group ID of the container |
 | kubernetes.securityContext.runAsUser | int | `10001` | User ID of the container |
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |

--- a/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
@@ -204,6 +204,7 @@ spec:
             cpu: {{ .Values.wso2.deployment.resources.limits.cpu }}
         securityContext:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.kubernetes.securityContext.runAsGroup }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           {{- if .Values.kubernetes.securityContext.seLinux.enabled }}

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -174,6 +174,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
     # -- SELinux context for the container
     seLinux:
       enabled: false

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -48,6 +48,7 @@ A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 | kubernetes.extraVolumeMounts | list | `[]` | Mount extra volumes to the deployment pods, e.g to mount secrets extraVolumeMounts:   - name: my-secret     mountPath: /opt/wso2/secrets     readOnly: true |
 | kubernetes.extraVolumes | list | `[]` | Define the extra volumes to be mounted extraVolumes:   - name: my-secret     secret:       secretName: my-k8s-secret |
 | kubernetes.openshift | object | `{"enabled":false}` | When deploying on OpenShift. |
+| kubernetes.securityContext.runAsGroup | int | `10001` | Group ID of the container |
 | kubernetes.securityContext.runAsUser | int | `10001` | User ID of the container |
 | kubernetes.securityContext.seLinux | object | `{"enabled":false,"level":""}` | SELinux context for the container |
 | kubernetes.securityContext.seccompProfile | object | `{"localhostProfile":"","type":"RuntimeDefault"}` | Seccomp profile for the container |

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -211,6 +211,7 @@ spec:
             cpu: {{ .Values.wso2.deployment.resources.limits.cpu }}
         securityContext:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.kubernetes.securityContext.runAsGroup }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           {{- if .Values.kubernetes.securityContext.seLinux.enabled }}

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -212,6 +212,7 @@ spec:
             cpu: {{ .Values.wso2.deployment.resources.limits.cpu }}
         securityContext:
           runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.kubernetes.securityContext.runAsGroup }}
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           {{- if .Values.kubernetes.securityContext.seLinux.enabled }}

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -102,6 +102,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
     # -- SELinux context for the container
     seLinux:
       enabled: false

--- a/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+++ b/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
@@ -175,6 +175,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
@@ -224,6 +224,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
@@ -175,6 +175,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
@@ -98,6 +98,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
@@ -224,6 +224,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
@@ -175,6 +175,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
@@ -146,6 +146,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
@@ -98,6 +98,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
@@ -175,6 +175,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
@@ -147,6 +147,8 @@ kubernetes:
   securityContext:
     # -- User ID of the container
     runAsUser: 10001
+    # -- Group ID of the container
+    runAsGroup: 10001
   # -- Enable AppArmor profiles for the deployment
   enableAppArmor: false
 


### PR DESCRIPTION
## Summary

- Adds `kubernetes.securityContext.runAsGroup` to all distributed chart `values.yaml` files (control-plane, traffic-manager, gateway, key-manager) — defaulting to `10001` to match the existing `runAsUser` default
- Adds `runAsGroup` to the `securityContext` block in all 5 distributed deployment templates
- Updates `resources/am-pattern-*/default_*_values.yaml` files (10 files) for distributed profiles accordingly

## Motivation

The `all-in-one` chart already exposes `runAsGroup` under `kubernetes.securityContext`. The distributed charts were inconsistent — they had `runAsUser` but lacked `runAsGroup`, making it impossible for customers with cluster security policies that require an explicit group ID to comply without modifying chart source.

This change brings all distributed charts in line with the all-in-one chart and is fully backward compatible (default value `10001` matches the existing pod UID).

## Files changed

- `distributed/*/values.yaml` (4 charts) — added `securityContext.runAsGroup: 10001`
- `distributed/*/templates/*/deployment.yaml` (5 deployment templates) — added `runAsGroup` to securityContext block
- `resources/am-pattern-*/default_*_values.yaml` (10 files for distributed patterns) — added `runAsGroup: 10001`

## Test plan

- [ ] `helm lint` passes on all 4 distributed charts
- [ ] `helm template` output shows `runAsGroup: 10001` in pod securityContext
- [ ] Custom `runAsGroup` value flows through correctly
- [ ] all-in-one chart is unaffected (already had the field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)