### PR TITLE
fix: set server_role to "default" for gateway and traffic-manager (main)

### DIFF
--- a/distributed/gateway/confs/deployment.toml
+++ b/distributed/gateway/confs/deployment.toml
@@ -1,7 +1,7 @@
 [server]
 hostname = "{{- if .Values.kubernetes.gatewayAPI.enabled -}}{{ .Values.kubernetes.gatewayAPI.gateway.hostname }}{{- else -}}{{ .Values.kubernetes.ingress.gateway.hostname }}{{- end -}}"
 node_ip = "$env{NODE_IP}"
-server_role = "gateway-worker"
+server_role = "default"
 offset = {{ .Values.wso2.apim.portOffset }}
 
 [user_store]

--- a/distributed/traffic-manager/confs/instance-1/deployment.toml
+++ b/distributed/traffic-manager/confs/instance-1/deployment.toml
@@ -1,7 +1,7 @@
 [server]
 hostname = "{{- if and .Values.kubernetes.gatewayAPI .Values.kubernetes.gatewayAPI.enabled .Values.kubernetes.gatewayAPI.trafficManager .Values.kubernetes.gatewayAPI.trafficManager.hostname -}}{{ .Values.kubernetes.gatewayAPI.trafficManager.hostname }}{{- else if and .Values.kubernetes.ingress .Values.kubernetes.ingress.trafficManager .Values.kubernetes.ingress.trafficManager.hostname -}}{{ .Values.kubernetes.ingress.trafficManager.hostname }}{{- else -}}tm.wso2.com{{- end -}}"
 node_ip = "$env{NODE_IP}"
-server_role = "traffic-manager"
+server_role = "default"
 
 [user_store]
 type = {{ .Values.wso2.apim.configurations.userStore.type | quote }}

--- a/distributed/traffic-manager/confs/instance-2/deployment.toml
+++ b/distributed/traffic-manager/confs/instance-2/deployment.toml
@@ -1,7 +1,7 @@
 [server]
 hostname = "{{- if and .Values.kubernetes.gatewayAPI .Values.kubernetes.gatewayAPI.enabled .Values.kubernetes.gatewayAPI.trafficManager .Values.kubernetes.gatewayAPI.trafficManager.hostname -}}{{ .Values.kubernetes.gatewayAPI.trafficManager.hostname }}{{- else if and .Values.kubernetes.ingress .Values.kubernetes.ingress.trafficManager .Values.kubernetes.ingress.trafficManager.hostname -}}{{ .Values.kubernetes.ingress.trafficManager.hostname }}{{- else -}}tm.wso2.com{{- end -}}"
 node_ip = "$env{NODE_IP}"
-server_role = "traffic-manager"
+server_role = "default"
 
 [user_store]
 type = {{ .Values.wso2.apim.configurations.userStore.type | quote }}


### PR DESCRIPTION
### Purpose
Fixes wso2/api-manager#5095

The distributed deployment Helm charts set profile-specific `server_role` values (`gateway-worker`, `traffic-manager`) instead of the standard `default` value used in the product distribution. This aligns them with the product pack.

### Changes
- `distributed/gateway/confs/deployment.toml`: `server_role = "gateway-worker"` → `"default"`
- `distributed/traffic-manager/confs/instance-1/deployment.toml`: `server_role = "traffic-manager"` → `"default"`
- `distributed/traffic-manager/confs/instance-2/deployment.toml`: `server_role = "traffic-manager"` → `"default"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)