### PR TITLE
[4.7.0] Update release version to 4.7.0-3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ gateway, key-manager, traffic-manager) share a single version. Versions follow t
 
 ## [Unreleased]
 
+## [4.7.0-3]
+
+### Added
+- MCP (Model Context Protocol) configuration to default values across all deployment patterns.
+
+### Fixed
+- MCP disable behaviour in `deployment.toml` for all-in-one and control-plane profiles.
+
 ## [4.7.0-2]
 
 ### Added
@@ -46,7 +54,8 @@ gateway, key-manager, traffic-manager) share a single version. Versions follow t
 - OAuth header config.
 - Consistency issue with `sync_runtime_artifacts`.
 
-[Unreleased]: https://github.com/wso2/helm-apim/compare/all-in-one-4.7.0-2...HEAD
+[Unreleased]: https://github.com/wso2/helm-apim/compare/all-in-one-4.7.0-3...HEAD
+[4.7.0-3]: https://github.com/wso2/helm-apim/compare/all-in-one-4.7.0-2...all-in-one-4.7.0-3
 [4.7.0-2]: https://github.com/wso2/helm-apim/compare/all-in-one-4.7.0-1...all-in-one-4.7.0-2
 [4.7.0-1]: https://github.com/wso2/helm-apim/compare/all-in-one-4.6.0-4...all-in-one-4.7.0-1
 

--- a/all-in-one/Chart.yaml
+++ b/all-in-one/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.7.0"
 description: A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 name: wso2am-all-in-one
-version: 4.7.0-2
+version: 4.7.0-3
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -1,6 +1,6 @@
 # wso2am-all-in-one
 
-![Version: 4.7.0-2](https://img.shields.io/badge/Version-4.7.0--2-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
+![Version: 4.7.0-3](https://img.shields.io/badge/Version-4.7.0--3-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
 
 A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 

--- a/distributed/control-plane/Chart.yaml
+++ b/distributed/control-plane/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.7.0"
 description: A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 name: wso2am-acp
-version: 4.7.0-2
+version: 4.7.0-3
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/distributed/control-plane/README.md
+++ b/distributed/control-plane/README.md
@@ -1,6 +1,6 @@
 # wso2am-acp
 
-![Version: 4.7.0-2](https://img.shields.io/badge/Version-4.7.0--2-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
+![Version: 4.7.0-3](https://img.shields.io/badge/Version-4.7.0--3-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
 
 A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 

--- a/distributed/gateway/Chart.yaml
+++ b/distributed/gateway/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.7.0"
 description: A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 name: wso2am-universal-gw
-version: 4.7.0-2
+version: 4.7.0-3
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -1,6 +1,6 @@
 # wso2am-universal-gw
 
-![Version: 4.7.0-2](https://img.shields.io/badge/Version-4.7.0--2-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
+![Version: 4.7.0-3](https://img.shields.io/badge/Version-4.7.0--3-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
 
 A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 

--- a/distributed/key-manager/Chart.yaml
+++ b/distributed/key-manager/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.7.0"
 description: A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 name: wso2am-km
-version: 4.7.0-2
+version: 4.7.0-3
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/distributed/key-manager/README.md
+++ b/distributed/key-manager/README.md
@@ -1,6 +1,6 @@
 # wso2am-km
 
-![Version: 4.7.0-2](https://img.shields.io/badge/Version-4.7.0--2-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
+![Version: 4.7.0-3](https://img.shields.io/badge/Version-4.7.0--3-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
 
 A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 

--- a/distributed/traffic-manager/Chart.yaml
+++ b/distributed/traffic-manager/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v1
 appVersion: "4.7.0"
 description: A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 name: wso2am-tm
-version: 4.7.0-2
+version: 4.7.0-3
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -1,6 +1,6 @@
 # wso2am-tm
 
-![Version: 4.7.0-2](https://img.shields.io/badge/Version-4.7.0--2-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
+![Version: 4.7.0-3](https://img.shields.io/badge/Version-4.7.0--3-informational?style=flat-square) ![AppVersion: 4.7.0](https://img.shields.io/badge/AppVersion-4.7.0-informational?style=flat-square)
 
 A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 


### PR DESCRIPTION
## Purpose

Prepare for the next release: **4.7.0-3** (following #246 which released 4.7.0-2).

## Changes

- Bump chart `version` `4.7.0-2` → `4.7.0-3` across `all-in-one` and the `distributed` charts (control-plane, gateway, key-manager, traffic-manager).
- Update helm-docs version badges in the corresponding `README.md` files.
- Add `CHANGELOG.md` entry for `4.7.0-3`:
  - **Added** — MCP (Model Context Protocol) configuration to default values across all deployment patterns (278ebde).
  - **Fixed** — MCP disable behaviour in `deployment.toml` for all-in-one and control-plane profiles (88dfbcc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)