### PR TITLE
[4.7.x] Add pod.labels support to all helm charts

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -393,7 +393,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.persistence.solrIndexing.capacity.solrIndexedData | string | `"50M"` | For persisting the indexed solr data |
 | wso2.deployment.persistence.solrIndexing.enabled | bool | `false` | Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled By default, this is disabled |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
-| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods. `deployment` and `node` are reserved for the Deployment selector and must not be overridden. |
 | wso2.deployment.readinessProbe.failureThreshold | int | `5` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -393,6 +393,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.persistence.solrIndexing.capacity.solrIndexedData | string | `"50M"` | For persisting the indexed solr data |
 | wso2.deployment.persistence.solrIndexing.enabled | bool | `false` | Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled By default, this is disabled |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
 | wso2.deployment.readinessProbe.failureThreshold | int | `5` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-1/wso2am-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         deployment: {{ template "am-all-in-one.fullname" . }}-am
         node: {{ template "am-all-in-one.fullname" . }}-am-1
         product: apim
+        {{- if .Values.wso2.deployment.pod.labels }}
+        {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
+++ b/all-in-one/templates/am/instance-2/wso2am-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         deployment: {{ template "am-all-in-one.fullname" . }}-am
         node: {{ template "am-all-in-one.fullname" . }}-am-2
         product: apim
+        {{- if .Values.wso2.deployment.pod.labels }}
+        {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -945,7 +945,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
-      # -- Labels for pods
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
       labels: {}
 
     # -- Environment variables for the deployment

--- a/all-in-one/values.yaml
+++ b/all-in-one/values.yaml
@@ -945,6 +945,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
+      # -- Labels for pods
+      labels: {}
 
     # -- Environment variables for the deployment
     # Example:

--- a/distributed/control-plane/README.md
+++ b/distributed/control-plane/README.md
@@ -263,6 +263,7 @@ A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 | wso2.deployment.persistence.solrIndexing.capacity.solrIndexedData | string | `"50M"` | For persisting the indexed solr data |
 | wso2.deployment.persistence.solrIndexing.enabled | bool | `false` | Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled By default, this is disabled |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
 | wso2.deployment.readinessProbe.failureThreshold | int | `3` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/distributed/control-plane/README.md
+++ b/distributed/control-plane/README.md
@@ -263,7 +263,7 @@ A Helm chart for the deployment of WSO2 API Management API Control Plane profile
 | wso2.deployment.persistence.solrIndexing.capacity.solrIndexedData | string | `"50M"` | For persisting the indexed solr data |
 | wso2.deployment.persistence.solrIndexing.enabled | bool | `false` | Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled By default, this is disabled |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
-| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods. `deployment` and `node` are reserved for the Deployment selector and must not be overridden. |
 | wso2.deployment.readinessProbe.failureThreshold | int | `3` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-1/wso2am-cp-deployment.yaml
@@ -38,6 +38,9 @@ spec:
         deployment: {{ template "apim-helm-cp.fullname" . }}
         node: {{ template "apim-helm-cp.fullname" . }}-1
         product: apim
+        {{- if .Values.wso2.deployment.pod.labels }}
+        {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
+++ b/distributed/control-plane/templates/control-plane/instance-2/wso2am-cp-deployment.yaml
@@ -39,6 +39,9 @@ spec:
         deployment: {{ template "apim-helm-cp.fullname" . }}
         node: {{ template "apim-helm-cp.fullname" . }}-2
         product: apim
+        {{- if .Values.wso2.deployment.pod.labels }}
+        {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -725,6 +725,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
+      # -- Labels for pods
+      labels: {}
 
     # -- Environment variables for the deployment
     # Example:

--- a/distributed/control-plane/values.yaml
+++ b/distributed/control-plane/values.yaml
@@ -725,7 +725,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
-      # -- Labels for pods
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
       labels: {}
 
     # -- Environment variables for the deployment

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -236,6 +236,7 @@ A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 | wso2.deployment.minReplicas | int | `2` | Minimum replicas for HPA |
 | wso2.deployment.nodeSelector | string | `nil` | Node selector to deploy pod in selected node. Add label to the node and specify the label here. |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
 | wso2.deployment.readinessProbe.failureThreshold | int | `3` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/distributed/gateway/README.md
+++ b/distributed/gateway/README.md
@@ -236,7 +236,7 @@ A Helm chart for the deployment of WSO2 API Management Universal Gateway profile
 | wso2.deployment.minReplicas | int | `2` | Minimum replicas for HPA |
 | wso2.deployment.nodeSelector | string | `nil` | Node selector to deploy pod in selected node. Add label to the node and specify the label here. |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
-| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods. `deployment` is reserved for the Deployment selector and must not be overridden. |
 | wso2.deployment.readinessProbe.failureThreshold | int | `3` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
+++ b/distributed/gateway/templates/gateway/wso2am-gateway-deployment.yaml
@@ -39,6 +39,9 @@ spec:
       labels:
         deployment: {{ template "apim-helm-gw.fullname" . }}
         product: apim
+        {{- if .Values.wso2.deployment.pod.labels }}
+        {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -659,6 +659,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
+      # -- Labels for pods
+      labels: {}
 
     # -- Environment variables for the deployment
     # Example:

--- a/distributed/gateway/values.yaml
+++ b/distributed/gateway/values.yaml
@@ -659,7 +659,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
-      # -- Labels for pods
+      # -- Labels for pods.
+      # `deployment` is reserved for the Deployment selector and must not be overridden.
       labels: {}
 
     # -- Environment variables for the deployment

--- a/distributed/key-manager/README.md
+++ b/distributed/key-manager/README.md
@@ -170,6 +170,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.minAvailable | string | `"50%"` | Minimum available pod counts for PDB |
 | wso2.deployment.nodeSelector | string | `nil` | Node selector to deploy pod in selected node. Add label to the node and specify the label here. |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
 | wso2.deployment.readinessProbe.failureThreshold | int | `3` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/distributed/key-manager/README.md
+++ b/distributed/key-manager/README.md
@@ -170,7 +170,7 @@ A Helm chart for the deployment of WSO2 API Manager all-in-one distribution.
 | wso2.deployment.minAvailable | string | `"50%"` | Minimum available pod counts for PDB |
 | wso2.deployment.nodeSelector | string | `nil` | Node selector to deploy pod in selected node. Add label to the node and specify the label here. |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
-| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods. `deployment` is reserved for the Deployment selector and must not be overridden. |
 | wso2.deployment.readinessProbe.failureThreshold | int | `3` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
+++ b/distributed/key-manager/templates/key-manager/wso2am-km-deployment.yaml
@@ -43,6 +43,9 @@ spec:
       labels:
         deployment: {{ template "apim-helm-km.fullname" . }}
         product: apim
+        {{- if .Values.wso2.deployment.pod.labels }}
+        {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -486,7 +486,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
-      # -- Labels for pods
+      # -- Labels for pods.
+      # `deployment` is reserved for the Deployment selector and must not be overridden.
       labels: {}
 
     # -- Environment variables for the deployment

--- a/distributed/key-manager/values.yaml
+++ b/distributed/key-manager/values.yaml
@@ -486,6 +486,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
+      # -- Labels for pods
+      labels: {}
 
     # -- Environment variables for the deployment
     # Example:

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -129,6 +129,7 @@ A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 | wso2.deployment.minAvailable | string | `"50%"` | Minimum available pod counts for PDB |
 | wso2.deployment.nodeSelector | string | `nil` | Node selector to deploy pod in selected node. Add label to the node and specify the label here. |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
 | wso2.deployment.readinessProbe.failureThreshold | int | `3` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/distributed/traffic-manager/README.md
+++ b/distributed/traffic-manager/README.md
@@ -129,7 +129,7 @@ A Helm chart for the deployment of WSO2 API Management Traffic Manager profile
 | wso2.deployment.minAvailable | string | `"50%"` | Minimum available pod counts for PDB |
 | wso2.deployment.nodeSelector | string | `nil` | Node selector to deploy pod in selected node. Add label to the node and specify the label here. |
 | wso2.deployment.pod.annotations | object | `{}` | Annotations for pods |
-| wso2.deployment.pod.labels | object | `{}` | Labels for pods |
+| wso2.deployment.pod.labels | object | `{}` | Labels for pods. `deployment` and `node` are reserved for the Deployment selector and must not be overridden. |
 | wso2.deployment.readinessProbe.failureThreshold | int | `3` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | wso2.deployment.readinessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before readiness probes are initiated |
 | wso2.deployment.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |

--- a/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-1/wso2am-tm-deployment.yaml
@@ -41,6 +41,9 @@ spec:
         deployment: {{ template "apim-helm-tm.fullname" . }}
         node: {{ template "apim-helm-tm.fullname" . }}-1
         product: apim
+        {{- if .Values.wso2.deployment.pod.labels }}
+        {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
+++ b/distributed/traffic-manager/templates/traffic-manager/instance-2/wso2am-tm-deployment.yaml
@@ -42,6 +42,9 @@ spec:
         deployment: {{ template "apim-helm-tm.fullname" . }}
         node: {{ template "apim-helm-tm.fullname" . }}-2
         product: apim
+        {{- if .Values.wso2.deployment.pod.labels }}
+        {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -402,7 +402,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
-      # -- Labels for pods
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
       labels: {}
 
     # -- Environment variables for the deployment

--- a/distributed/traffic-manager/values.yaml
+++ b/distributed/traffic-manager/values.yaml
@@ -402,6 +402,8 @@ wso2:
     pod:
       # -- Annotations for pods
       annotations: {}
+      # -- Labels for pods
+      labels: {}
 
     # -- Environment variables for the deployment
     # Example:

--- a/resources/am-pattern-0-all-in-one/default_values.yaml
+++ b/resources/am-pattern-0-all-in-one/default_values.yaml
@@ -766,6 +766,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     persistence:
       # -- Persistent runtime artifacts for Apache Solr-based indexing
       solrIndexing:

--- a/resources/am-pattern-1-all-in-one-HA/default_values.yaml
+++ b/resources/am-pattern-1-all-in-one-HA/default_values.yaml
@@ -785,6 +785,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     persistence:
       # -- Persistent runtime artifacts for Apache Solr-based indexing
       solrIndexing:

--- a/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+++ b/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
@@ -536,6 +536,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` is reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # Kubernetes RollingUpdate strategy configurations
     strategy:
       rollingUpdate:

--- a/resources/am-pattern-2-all-in-one_GW/default_values.yaml
+++ b/resources/am-pattern-2-all-in-one_GW/default_values.yaml
@@ -759,6 +759,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     persistence:
       # -- Persistent runtime artifacts for Apache Solr-based indexing
       solrIndexing:

--- a/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
@@ -583,6 +583,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # -- Enable high availability for traffic manager. If this is enabled, two traffic manager instances will be deployed.
     # This is not relavant to HA in Kubernetes. Multiple replicas of the same instance will not count as HA for TM.
     highAvailability: true

--- a/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
@@ -538,6 +538,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` is reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # Kubernetes RollingUpdate strategy configurations
     strategy:
       rollingUpdate:

--- a/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
+++ b/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
@@ -326,6 +326,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # Kubernetes RollingUpdate strategy configurations
     strategy:
       rollingUpdate:

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
@@ -583,6 +583,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # -- Enable high availability for traffic manager. If this is enabled, two traffic manager instances will be deployed.
     # This is not relavant to HA in Kubernetes. Multiple replicas of the same instance will not count as HA for TM.
     highAvailability: true

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
@@ -538,6 +538,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` is reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # Kubernetes RollingUpdate strategy configurations
     strategy:
       rollingUpdate:

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
@@ -404,6 +404,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` is reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # Kubernetes RollingUpdate strategy configurations
     strategy:
       rollingUpdate:

--- a/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
+++ b/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
@@ -326,6 +326,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # Kubernetes RollingUpdate strategy configurations
     strategy:
       rollingUpdate:

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
@@ -536,6 +536,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` is reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # Kubernetes RollingUpdate strategy configurations
     strategy:
       rollingUpdate:

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
@@ -404,6 +404,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` is reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     # Kubernetes RollingUpdate strategy configurations
     strategy:
       rollingUpdate:

--- a/resources/am-pattern-5-all-in-one_GW_KM/default_values.yaml
+++ b/resources/am-pattern-5-all-in-one_GW_KM/default_values.yaml
@@ -767,6 +767,14 @@ wso2:
     # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
     nodeSelector:
 
+    # Pod-specific configurations
+    pod:
+      # -- Annotations for pods
+      annotations: {}
+      # -- Labels for pods.
+      # `deployment` and `node` are reserved for the Deployment selector and must not be overridden.
+      labels: {}
+
     persistence:
       # -- Persistent runtime artifacts for Apache Solr-based indexing
       solrIndexing:


### PR DESCRIPTION
## Purpose
Port of #174 (merged to `4.6.x`) so that `wso2.deployment.pod.labels` is available on this branch too.

## Goals
Add `wso2.deployment.pod.labels` configuration to all WSO2 APIM helm charts, enabling users to set custom labels for pod organization, monitoring, cost allocation, and policy enforcement.

## Approach
Added `pod.labels: {}` to `values.yaml` and updated the deployment templates to merge custom labels with the default labels in all 5 charts:
- `all-in-one` (2 instances)
- `distributed/control-plane` (2 instances)
- `distributed/gateway`
- `distributed/key-manager`
- `distributed/traffic-manager` (2 instances)

Implementation follows the existing `pod.annotations` pattern for consistency.

**Template changes:**
```yaml
labels:
  deployment: {{ template "chart.fullname" . }}
  product: apim
  {{- if .Values.wso2.deployment.pod.labels }}
  {{- toYaml .Values.wso2.deployment.pod.labels | nindent 8 }}
  {{- end }}
```

**Usage example:**
```yaml
wso2:
  deployment:
    pod:
      annotations:
        prometheus.io/scrape: "true"
      labels:
        team: platform
        environment: production
        cost-center: engineering
```

## Release note
Added support for custom pod labels via `wso2.deployment.pod.labels` configuration in all helm charts.

## Documentation
`README.md` files for all 5 charts regenerated with `helm-docs` (v1.14.2).

## Automation tests
- Unit tests: N/A (helm charts)
- Integration tests: `helm lint` passes for all 5 charts; `helm template` verified with both default values (output identical to before) and custom `pod.labels` (labels correctly merged into the pod template).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (YAML templates only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
- #174 (original, merged to `4.6.x`)

## Migrations (if applicable)
N/A - Backward compatible. Default value is an empty map `{}`, producing identical output to previous versions.

## Test environment
- Helm 3.x
- helm-docs 1.14.2
